### PR TITLE
Feature/advanced festival info page

### DIFF
--- a/src/__tests__/pages/FestivalInfoPage.test.tsx
+++ b/src/__tests__/pages/FestivalInfoPage.test.tsx
@@ -373,7 +373,7 @@ describe('리뷰 섹션 컴포넌트', () => {
 
     // Then: 리뷰 섹션 헤더와 첫 리뷰 작성자 노출
     expect(screen.getByText(/리뷰 \(\d+\)/)).toBeInTheDocument();
-    const firstReviewer = reviewMockData.content[0].reviwerName;
+    const firstReviewer = reviewMockData.content[0].reviewerName;
     expect(screen.getByText(firstReviewer)).toBeInTheDocument();
   });
 
@@ -383,7 +383,7 @@ describe('리뷰 섹션 컴포넌트', () => {
     await screen.findByText('가평 양떼목장 수국축제');
 
     // When: 첫 번째 리뷰 카드 내의 첫 이미지 썸네일을 클릭
-    const firstReviewer = reviewMockData.content[0].reviwerName;
+    const firstReviewer = reviewMockData.content[0].reviewerName;
     const reviewer = screen.getByText(firstReviewer);
     const reviewCard = reviewer.closest('div')?.parentElement; // 카드 컨테이너
     const firstImage = reviewCard?.querySelector('img');
@@ -412,7 +412,7 @@ describe('리뷰 섹션 컴포넌트', () => {
     await screen.findByText('가평 양떼목장 수국축제');
 
     // When: 두 번째 리뷰 카드 내의 비디오 썸네일(비디오 요소)을 클릭
-    const secondReviewer = reviewMockData.content[1].reviwerName;
+    const secondReviewer = reviewMockData.content[1].reviewerName;
     const reviewer = screen.getByText(secondReviewer);
     const reviewCard = reviewer.closest('div')?.parentElement; // 카드 컨테이너
     const videoEl = reviewCard?.querySelector('video') as HTMLVideoElement | null;

--- a/src/__tests__/pages/FestivalInfoPage.test.tsx
+++ b/src/__tests__/pages/FestivalInfoPage.test.tsx
@@ -6,6 +6,7 @@ import { ROUTE_PATH } from '@/constants/routes';
 import FestivalPoster from '@/pages/FestivalInfo/components/FestivalPoster';
 import { festivalInfoMockData } from '@/mocks/data/festivalInfo.mock';
 import { waitFor } from '@testing-library/react';
+import { reviewMockData } from '@/mocks/data/review.mock';
 
 const createTestClient = () =>
   new QueryClient({
@@ -358,6 +359,75 @@ describe('FestivalPoster 컴포넌트', () => {
 
       expect(prevButton).toHaveClass('hidden', 'md:flex');
       expect(nextButton).toHaveClass('hidden', 'md:flex');
+    });
+  });
+});
+
+describe('리뷰 섹션 컴포넌트', () => {
+  test('리뷰 섹션이 로드되고 첫 리뷰의 작성자와 별점이 보인다', async () => {
+    // Given: 축제 상세 페이지 렌더링
+    render(<TestWrapper />);
+
+    // When: 데이터가 로드될 때까지 대기
+    await screen.findByText('가평 양떼목장 수국축제');
+
+    // Then: 리뷰 섹션 헤더와 첫 리뷰 작성자 노출
+    expect(screen.getByText(/리뷰 \(\d+\)/)).toBeInTheDocument();
+    const firstReviewer = reviewMockData.content[0].reviwerName;
+    expect(screen.getByText(firstReviewer)).toBeInTheDocument();
+  });
+
+  test('이미지 리뷰 썸네일 클릭 시 모달이 열리고 카운터가 표시된다 (이미지 전용)', async () => {
+    // Given: 페이지 렌더링 및 데이터 로드
+    render(<TestWrapper />);
+    await screen.findByText('가평 양떼목장 수국축제');
+
+    // When: 첫 번째 리뷰 카드 내의 첫 이미지 썸네일을 클릭
+    const firstReviewer = reviewMockData.content[0].reviwerName;
+    const reviewer = screen.getByText(firstReviewer);
+    const reviewCard = reviewer.closest('div')?.parentElement; // 카드 컨테이너
+    const firstImage = reviewCard?.querySelector('img');
+    expect(firstImage).toBeTruthy();
+    firstImage && fireEvent.click(firstImage);
+
+    // Then: 모달 닫기 버튼, 미디어 카운터, 다음 화살표가 보인다
+    expect(await screen.findByRole('button', { name: '모달 닫기' })).toBeInTheDocument();
+    expect(screen.getByText(/\d+ \/ \d+/)).toBeInTheDocument();
+    expect(screen.getByLabelText('다음 미디어')).toBeInTheDocument();
+
+    // And: 다음으로 이동하면 카운터가 증가한다
+    fireEvent.click(screen.getByLabelText('다음 미디어'));
+    expect(screen.getByText(/2 \/ \d+/)).toBeInTheDocument();
+
+    // And: 모달을 닫을 수 있다
+    fireEvent.click(screen.getByRole('button', { name: '모달 닫기' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '모달 닫기' })).not.toBeInTheDocument();
+    });
+  });
+
+  test('비디오가 포함된 리뷰에서 비디오 썸네일 클릭 시 모달 오픈 및 화살표 표시', async () => {
+    // Given: 페이지 렌더링 및 데이터 로드
+    render(<TestWrapper />);
+    await screen.findByText('가평 양떼목장 수국축제');
+
+    // When: 두 번째 리뷰 카드 내의 비디오 썸네일(비디오 요소)을 클릭
+    const secondReviewer = reviewMockData.content[1].reviwerName;
+    const reviewer = screen.getByText(secondReviewer);
+    const reviewCard = reviewer.closest('div')?.parentElement; // 카드 컨테이너
+    const videoEl = reviewCard?.querySelector('video') as HTMLVideoElement | null;
+    expect(videoEl).toBeTruthy();
+    videoEl && fireEvent.click(videoEl);
+
+    // Then: 모달이 열리고 화살표는 hidden md:flex 클래스를 가진다
+    const nextBtn = await screen.findByLabelText('다음 미디어');
+    expect(nextBtn).toHaveClass('hidden', 'md:flex');
+    expect(screen.getByText(/\d+ \/ \d+/)).toBeInTheDocument();
+
+    // And: 모달 닫기 가능
+    fireEvent.click(screen.getByRole('button', { name: '모달 닫기' }));
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: '모달 닫기' })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/__tests__/pages/FestivalInfoPage.test.tsx
+++ b/src/__tests__/pages/FestivalInfoPage.test.tsx
@@ -3,6 +3,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import FestivalInfoPage from '@/pages/FestivalInfo/FestivalInfoPage';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ROUTE_PATH } from '@/constants/routes';
+import FestivalPoster from '@/pages/FestivalInfo/components/FestivalPoster';
+import { festivalInfoMockData } from '@/mocks/data/festivalInfo.mock';
+import { waitFor } from '@testing-library/react';
 
 const createTestClient = () =>
   new QueryClient({
@@ -113,6 +116,248 @@ describe('FestivalInfoPage 테스트', () => {
       // Then: 더보기 버튼으로 돌아가고, 말줄임표가 다시 보인다
       expect(await screen.findByRole('button', { name: '더보기' })).toBeInTheDocument();
       expect(screen.getByText(/\.\.\.$/)).toBeInTheDocument();
+    });
+  });
+});
+
+describe('FestivalPoster 컴포넌트', () => {
+  const mockProps = {
+    posterUrl: festivalInfoMockData.content.posterInfo,
+    imageUrls: festivalInfoMockData.content.imageInfos,
+    title: festivalInfoMockData.content.title,
+  };
+
+  const singleImageProps = {
+    posterUrl: festivalInfoMockData.content.posterInfo,
+    imageUrls: [],
+    title: '단일 이미지 축제',
+  };
+
+  describe('스냅샷 테스트', () => {
+    test('기본 FestivalPoster 컴포넌트 스냅샷', () => {
+      const { container } = render(<FestivalPoster {...mockProps} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('단일 이미지 FestivalPoster 스냅샷', () => {
+      const { container } = render(<FestivalPoster {...singleImageProps} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+
+    test('많은 이미지가 있는 FestivalPoster 스냅샷', () => {
+      const manyImagesProps = {
+        ...mockProps,
+        imageUrls: [
+          'https://example.com/image1.jpg',
+          'https://example.com/image2.jpg',
+          'https://example.com/image3.jpg',
+          'https://example.com/image4.jpg',
+        ],
+      };
+      const { container } = render(<FestivalPoster {...manyImagesProps} />);
+      expect(container.firstChild).toMatchSnapshot();
+    });
+  });
+
+  describe('조건부 렌더링', () => {
+    test('단일 이미지일 때 화살표 버튼과 인디케이터가 표시되지 않는다', () => {
+      render(<FestivalPoster {...singleImageProps} />);
+
+      // 화살표 버튼 없음
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('다음 이미지')).not.toBeInTheDocument();
+
+      // 인디케이터 없음
+      const indicators = screen
+        .queryAllByRole('button')
+        .filter((button) => !button.getAttribute('aria-label'));
+      expect(indicators).toHaveLength(0);
+    });
+
+    test('여러 이미지가 있을 때 화살표 버튼과 인디케이터가 표시된다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 첫 번째 이미지에서는 다음 버튼만 표시
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+
+      // 6개의 인디케이터 표시 (포스터 + 5개 추가 이미지)
+      const indicators = screen
+        .getAllByRole('button')
+        .filter((button) => !button.getAttribute('aria-label'));
+      expect(indicators).toHaveLength(6);
+    });
+  });
+
+  describe('화살표 버튼 상호작용', () => {
+    test('다음 버튼 클릭 시 이미지가 변경되고 이전 버튼이 나타난다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 초기 상태: 다음 버튼만 있음
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+
+      // 다음 버튼 클릭
+      const nextButton = screen.getByLabelText('다음 이미지');
+      fireEvent.click(nextButton);
+
+      // 이미지 변경 후: 이전 버튼이 나타남
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+    });
+
+    test('이전 버튼 클릭 시 첫 번째 이미지로 돌아가고 이전 버튼이 사라진다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 먼저 다음 이미지로 이동
+      fireEvent.click(screen.getByLabelText('다음 이미지'));
+
+      // 이전 버튼이 나타났는지 확인
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+
+      // 이전 버튼 클릭
+      const prevButton = screen.getByLabelText('이전 이미지');
+      fireEvent.click(prevButton);
+
+      // 첫 번째 이미지로 돌아감: 이전 버튼 사라짐
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+    });
+
+    test('마지막 이미지에서 다음 버튼이 사라진다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 마지막 이미지까지 이동 (총 6개 이미지)
+      for (let i = 0; i < 5; i++) {
+        fireEvent.click(screen.getByLabelText('다음 이미지'));
+      }
+
+      // 마지막 이미지: 다음 버튼 사라짐, 이전 버튼만 있음
+      expect(screen.queryByLabelText('다음 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+    });
+
+    test('연속 클릭으로 처음과 마지막 이미지를 확인할 수 있다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 1번째 → 2번째 이미지
+      fireEvent.click(screen.getByLabelText('다음 이미지'));
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+
+      // 마지막 이미지까지 이동
+      for (let i = 0; i < 4; i++) {
+        fireEvent.click(screen.getByLabelText('다음 이미지'));
+      }
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+      expect(screen.queryByLabelText('다음 이미지')).not.toBeInTheDocument();
+
+      // 마지막 → 첫 번째 이미지로 돌아가기
+      for (let i = 0; i < 5; i++) {
+        fireEvent.click(screen.getByLabelText('이전 이미지'));
+      }
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+    });
+  });
+
+  describe('인디케이터 상호작용', () => {
+    test('인디케이터 클릭 시 해당 이미지로 이동한다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      const indicators = screen
+        .getAllByRole('button')
+        .filter((button) => !button.getAttribute('aria-label'));
+
+      // 마지막 인디케이터 클릭 (마지막 이미지)
+      fireEvent.click(indicators[5]);
+
+      // 이전 버튼만 표시되어야 함
+      expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+      expect(screen.queryByLabelText('다음 이미지')).not.toBeInTheDocument();
+    });
+
+    test('현재 활성 인디케이터가 올바른 스타일을 가진다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      const indicators = screen
+        .getAllByRole('button')
+        .filter((button) => !button.getAttribute('aria-label'));
+
+      // 첫 번째 인디케이터가 활성 상태여야 함
+      expect(indicators[0]).toHaveClass('bg-primary-300');
+      // 나머지 인디케이터들은 비활성 상태
+      for (let i = 1; i < indicators.length; i++) {
+        expect(indicators[i]).toHaveClass('bg-gray-300');
+      }
+    });
+  });
+
+  describe('터치 스와이프 기능', () => {
+    test('충분한 거리 스와이프 시 이미지가 변경된다', async () => {
+      const { container } = render(<FestivalPoster {...mockProps} />);
+      const posterContainer = container.querySelector('.h-\\[500px\\]');
+
+      // 왼쪽으로 스와이프 (다음 이미지로)
+      fireEvent.touchStart(posterContainer!, {
+        touches: [{ clientX: 200 }],
+      });
+      fireEvent.touchMove(posterContainer!, {
+        touches: [{ clientX: 100 }],
+      });
+      fireEvent.touchEnd(posterContainer!);
+
+      // 이미지 변경 확인
+      await waitFor(() => {
+        expect(screen.getByLabelText('이전 이미지')).toBeInTheDocument();
+      });
+    });
+
+    test('임계값 미만 스와이프 시 이미지가 변경되지 않는다', () => {
+      const { container } = render(<FestivalPoster {...mockProps} />);
+      const posterContainer = container.querySelector('.h-\\[500px\\]');
+
+      // 작은 거리 스와이프
+      fireEvent.touchStart(posterContainer!, {
+        touches: [{ clientX: 100 }],
+      });
+      fireEvent.touchMove(posterContainer!, {
+        touches: [{ clientX: 80 }],
+      });
+      fireEvent.touchEnd(posterContainer!);
+
+      // 이미지 변경되지 않음 확인
+      expect(screen.queryByLabelText('이전 이미지')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+    });
+  });
+
+  describe('접근성 및 스타일링', () => {
+    test('이미지와 버튼이 적절한 접근성 속성을 가진다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 이미지 alt 텍스트 확인
+      const images = screen.getAllByRole('img');
+      images.forEach((img, index) => {
+        expect(img).toHaveAttribute('alt', `${mockProps.title} - ${index + 1}`);
+        expect(img).toHaveAttribute('draggable', 'false');
+      });
+
+      // 네비게이션 버튼 aria-label 확인
+      expect(screen.getByLabelText('다음 이미지')).toBeInTheDocument();
+    });
+
+    test('화살표 버튼이 데스크톱에서만 표시되는 클래스를 가진다', () => {
+      render(<FestivalPoster {...mockProps} />);
+
+      // 다음 버튼으로 이동해서 이전 버튼도 표시되게 함
+      fireEvent.click(screen.getByLabelText('다음 이미지'));
+
+      const prevButton = screen.getByLabelText('이전 이미지');
+      const nextButton = screen.getByLabelText('다음 이미지');
+
+      expect(prevButton).toHaveClass('hidden', 'md:flex');
+      expect(nextButton).toHaveClass('hidden', 'md:flex');
     });
   });
 });

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -228,7 +228,9 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
             class="flex items-center justify-center w-fit cursor-pointer bg-transparent text-gray-400 text-sm !p-0 !rounded-none text-md rounded-xl px-5 py-3 text-gray-900 "
             type="button"
           />
-          <div>
+          <div
+            class="cursor-pointer"
+          >
             <svg
               aria-hidden="true"
               class="lucide lucide-heart"

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -104,11 +104,120 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
     <div
       class="flex flex-col items-center w-full h-full"
     >
-      <img
-        alt="가평 양떼목장 수국축제"
-        class="w-full h-full object-cover"
-        src="http://tong.visitkorea.or.kr/cms/resource/88/3503888_image2_1.png"
-      />
+      <div
+        class="w-full relative"
+      >
+        <div
+          class="relative w-full h-[500px] overflow-hidden"
+        >
+          <div
+            class="flex transition-transform duration-300 ease-out h-full"
+            style="transform: translateX(0%);"
+          >
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 1"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/88/3503888_image2_1.png"
+              />
+            </div>
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 2"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg"
+              />
+            </div>
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 3"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg"
+              />
+            </div>
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 4"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg"
+              />
+            </div>
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 5"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg"
+              />
+            </div>
+            <div
+              class="w-full h-full flex-shrink-0"
+            >
+              <img
+                alt="가평 양떼목장 수국축제 - 6"
+                class="w-full h-full object-contain select-none bg-gray-50"
+                draggable="false"
+                src="http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg"
+              />
+            </div>
+          </div>
+          <button
+            aria-label="다음 이미지"
+            class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex right-4"
+          >
+            <svg
+              class="stroke-white"
+              fill="none"
+              height="28"
+              stroke="black"
+              stroke-width="3"
+              viewBox="0 0 24 24"
+              width="28"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8 4 L16 12 L8 20"
+              />
+            </svg>
+          </button>
+        </div>
+        <div
+          class="flex justify-center mt-2 gap-1"
+        >
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-primary-300"
+          />
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+          />
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+          />
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+          />
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+          />
+          <button
+            class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+          />
+        </div>
+      </div>
       <div
         class="w-full h-full p-4 gap-4 flex flex-col"
       >

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -325,6 +325,10 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
             </button>
           </div>
         </div>
+        <div
+          class="w-full bg-gray-400"
+          style="height: 1px;"
+        />
       </div>
     </div>
     <div

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -263,6 +263,159 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
             가평 양떼목장 수국축제
           </h1>
           <div
+            class="flex items-center gap-2 text-sm text-gray-700"
+          >
+            <div
+              class="flex items-center gap-1"
+            >
+              <div
+                class="flex items-center"
+              >
+                <div
+                  class="relative"
+                >
+                  <svg
+                    class="w-4 h-4 text-gray-300"
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                  <svg
+                    class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="relative"
+                >
+                  <svg
+                    class="w-4 h-4 text-gray-300"
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                  <svg
+                    class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="relative"
+                >
+                  <svg
+                    class="w-4 h-4 text-gray-300"
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                  <svg
+                    class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="relative"
+                >
+                  <svg
+                    class="w-4 h-4 text-gray-300"
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                  <svg
+                    class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                </div>
+                <div
+                  class="relative"
+                >
+                  <svg
+                    class="w-4 h-4 text-gray-300"
+                    fill="currentColor"
+                    stroke="none"
+                    stroke-width="0"
+                    viewBox="0 0 20 20"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <span
+                class="text-sm text-gray-600 ml-1"
+              >
+                4.3
+              </span>
+            </div>
+            <div
+              class="w-px h-3 bg-gray-500"
+            />
+            <p>
+              리뷰 
+              3
+              건
+            </p>
+          </div>
+          <div
             class="w-full h-full flex items-center gap-2"
           >
             <img
@@ -329,6 +482,629 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
           class="w-full bg-gray-400"
           style="height: 1px;"
         />
+        <div
+          class="w-full h-full flex flex-col gap-2"
+        >
+          <h3
+            class="text-sm text-gray-900 font-bold"
+          >
+            리뷰 (
+            3
+            )
+          </h3>
+          <div
+            class="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
+          >
+            <div
+              class="flex items-center justify-between"
+            >
+              <p
+                class="font-medium text-gray-900"
+              >
+                홍길동
+              </p>
+              <div
+                class="flex items-center gap-1"
+              >
+                <div
+                  class="flex items-center"
+                >
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="relative w-full h-full"
+            >
+              <div
+                class="flex overflow-x-scroll gap-2 pb-2 h-full md:pb-4"
+              >
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg"
+                  />
+                </div>
+              </div>
+            </div>
+            <p
+              class="text-sm text-gray-700"
+            >
+              꽃이 예뻐요.
+            </p>
+          </div>
+          <div
+            class="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
+          >
+            <div
+              class="flex items-center justify-between"
+            >
+              <p
+                class="font-medium text-gray-900"
+              >
+                이영희
+              </p>
+              <div
+                class="flex items-center gap-1"
+              >
+                <div
+                  class="flex items-center"
+                >
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class="relative w-full h-full"
+            >
+              <div
+                class="flex overflow-x-scroll gap-2 pb-2 h-full md:pb-4"
+              >
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <div
+                    class="relative w-full h-full"
+                  >
+                    <video
+                      class="w-full h-full object-cover"
+                      src="https://video.com/2.mp4"
+                    />
+                    <div
+                      class="absolute inset-0 flex items-center justify-center bg-black/30 transition-all cursor-pointer"
+                    >
+                      <div
+                        class="size-10 bg-black/60 rounded-full flex items-center justify-center"
+                      >
+                        <svg
+                          class="text-white"
+                          fill="none"
+                          height="16"
+                          viewBox="0 0 24 24"
+                          width="16"
+                        >
+                          <path
+                            d="M8 5v14l11-7z"
+                            fill="currentColor"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg"
+                  />
+                </div>
+                <div
+                  class="relative flex-shrink-0 size-32 rounded-lg overflow-hidden"
+                >
+                  <img
+                    alt="리뷰 이미지"
+                    class="w-full h-full object-cover cursor-pointer transition-transform"
+                    src="http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg"
+                  />
+                </div>
+              </div>
+            </div>
+            <p
+              class="text-sm text-gray-700"
+            >
+              행사가 재밌었어요.
+            </p>
+          </div>
+          <div
+            class="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
+          >
+            <div
+              class="flex items-center justify-between"
+            >
+              <p
+                class="font-medium text-gray-900"
+              >
+                박철수
+              </p>
+              <div
+                class="flex items-center gap-1"
+              >
+                <div
+                  class="flex items-center"
+                >
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                    <svg
+                      class="w-4 h-4 text-yellow-400 absolute top-0 left-0 "
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="relative"
+                  >
+                    <svg
+                      class="w-4 h-4 text-gray-300"
+                      fill="currentColor"
+                      stroke="none"
+                      stroke-width="0"
+                      viewBox="0 0 20 20"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <p
+              class="text-sm text-gray-700"
+            >
+              볼거리가 많았고 식사도 맛있었어요.
+            </p>
+          </div>
+        </div>
       </div>
     </div>
     <div
@@ -363,6 +1139,253 @@ exports[`FestivalInfoPage 테스트 > 스냅샷 테스트 > 로딩 완료 스냅
         </a>
       </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 기본 FestivalPoster 컴포넌트 스냅샷 1`] = `
+<div
+  class="w-full relative"
+>
+  <div
+    class="relative w-full h-[500px] overflow-hidden"
+  >
+    <div
+      class="flex transition-transform duration-300 ease-out h-full"
+      style="transform: translateX(0%);"
+    >
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 1"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/88/3503888_image2_1.png"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 2"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 3"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 4"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 5"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 6"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg"
+        />
+      </div>
+    </div>
+    <button
+      aria-label="다음 이미지"
+      class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex right-4"
+    >
+      <svg
+        class="stroke-white"
+        fill="none"
+        height="28"
+        stroke="black"
+        stroke-width="3"
+        viewBox="0 0 24 24"
+        width="28"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 4 L16 12 L8 20"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    class="flex justify-center mt-2 gap-1"
+  >
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-primary-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+  </div>
+</div>
+`;
+
+exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 단일 이미지 FestivalPoster 스냅샷 1`] = `
+<div
+  class="w-full relative"
+>
+  <div
+    class="relative w-full h-[500px] overflow-hidden"
+  >
+    <div
+      class="flex transition-transform duration-300 ease-out h-full"
+      style="transform: translateX(0%);"
+    >
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="단일 이미지 축제 - 1"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/88/3503888_image2_1.png"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 많은 이미지가 있는 FestivalPoster 스냅샷 1`] = `
+<div
+  class="w-full relative"
+>
+  <div
+    class="relative w-full h-[500px] overflow-hidden"
+  >
+    <div
+      class="flex transition-transform duration-300 ease-out h-full"
+      style="transform: translateX(0%);"
+    >
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 1"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="http://tong.visitkorea.or.kr/cms/resource/88/3503888_image2_1.png"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 2"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="https://example.com/image1.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 3"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="https://example.com/image2.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 4"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="https://example.com/image3.jpg"
+        />
+      </div>
+      <div
+        class="w-full h-full flex-shrink-0"
+      >
+        <img
+          alt="가평 양떼목장 수국축제 - 5"
+          class="w-full h-full object-contain select-none bg-gray-50"
+          draggable="false"
+          src="https://example.com/image4.jpg"
+        />
+      </div>
+    </div>
+    <button
+      aria-label="다음 이미지"
+      class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex right-4"
+    >
+      <svg
+        class="stroke-white"
+        fill="none"
+        height="28"
+        stroke="black"
+        stroke-width="3"
+        viewBox="0 0 24 24"
+        width="28"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 4 L16 12 L8 20"
+        />
+      </svg>
+    </button>
+  </div>
+  <div
+    class="flex justify-center mt-2 gap-1"
+  >
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-primary-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
+    <button
+      class="w-2 h-2 rounded-full transition-colors bg-gray-300"
+    />
   </div>
 </div>
 `;

--- a/src/apis/apiResponse.ts
+++ b/src/apis/apiResponse.ts
@@ -1,0 +1,37 @@
+export interface ApiResponseList<T> {
+  content: T[];
+  pageable: {
+    pageNumber: number;
+    pageSize: number;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    offset: number;
+    paged: boolean;
+    unpaged: boolean;
+  };
+  last: boolean;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  size: number;
+  number: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  numberOfElements: number;
+}
+
+export interface ApiResponseItem<T> {
+  content: T;
+}
+
+export interface ApiErrorResponse {
+  // 수정 필요
+  status: number;
+  message: string;
+}

--- a/src/apis/festivals/getFestivalInfo.ts
+++ b/src/apis/festivals/getFestivalInfo.ts
@@ -1,18 +1,15 @@
 import { apiInstance } from '@/apis/apiInstance';
 import API_ENDPOINTS from '@/constants/apiEndpoints';
 import type { FestivalInfo } from '@/types/FestivalType';
+import type { ApiResponseItem } from '@/apis/apiResponse';
 import type { ApiErrorResponse } from '@/apis/apiInstance';
 import type { AxiosResponse } from 'axios';
 import { generatePath } from 'react-router-dom';
 
-export interface GetFestivalInfoResponse {
-  content: FestivalInfo;
-}
-
 export const getFestivalInfo = async (params: {
   festivalId: string;
-}): Promise<AxiosResponse<GetFestivalInfoResponse, ApiErrorResponse>> => {
-  return await apiInstance.get<GetFestivalInfoResponse>(
+}): Promise<AxiosResponse<ApiResponseItem<FestivalInfo>, ApiErrorResponse>> => {
+  return await apiInstance.get<ApiResponseItem<FestivalInfo>>(
     generatePath(API_ENDPOINTS.FESTIVAL_INFO, { festivalId: params.festivalId }),
   );
 };

--- a/src/apis/festivals/getFestivals.ts
+++ b/src/apis/festivals/getFestivals.ts
@@ -1,42 +1,15 @@
 import { apiInstance } from '@/apis/apiInstance';
 import API_ENDPOINTS from '@/constants/apiEndpoints';
+import type { ApiResponseList } from '@/apis/apiResponse';
 import type { Festival } from '@/types/FestivalType';
 import type { ApiErrorResponse } from '@/apis/apiInstance';
 import type { AxiosResponse } from 'axios';
 import { generatePath } from 'react-router-dom';
 
-export interface GetFestivalsResponse {
-  content: Festival[];
-  pageable: {
-    pageNumber: number;
-    pageSize: number;
-    sort: {
-      empty: boolean;
-      sorted: boolean;
-      unsorted: boolean;
-    };
-    offset: number;
-    paged: boolean;
-    unpaged: boolean;
-  };
-  last: boolean;
-  totalElements: number;
-  totalPages: number;
-  first: boolean;
-  size: number;
-  number: number;
-  sort: {
-    empty: boolean;
-    sorted: boolean;
-    unsorted: boolean;
-  };
-  numberOfElements: number;
-}
-
 export const getFestivals = async (params: {
   areaId: string;
-}): Promise<AxiosResponse<GetFestivalsResponse, ApiErrorResponse>> => {
-  return await apiInstance.get<GetFestivalsResponse>(
+}): Promise<AxiosResponse<ApiResponseList<Festival>, ApiErrorResponse>> => {
+  return await apiInstance.get<ApiResponseList<Festival>>(
     generatePath(API_ENDPOINTS.FESTIVALS, { areaId: params.areaId }),
   );
 };

--- a/src/apis/review/getReview.ts
+++ b/src/apis/review/getReview.ts
@@ -7,7 +7,7 @@ import { generatePath } from 'react-router-dom';
 
 export interface Review {
   reviewId: string;
-  reviwerName: string;
+  reviewerName: string;
   festivalTitle: string;
   content: string;
   score: number;

--- a/src/apis/review/getReview.ts
+++ b/src/apis/review/getReview.ts
@@ -1,0 +1,25 @@
+import { apiInstance } from '@/apis/apiInstance';
+import API_ENDPOINTS from '@/constants/apiEndpoints';
+import type { ApiResponseList } from '@/apis/apiResponse';
+import type { ApiErrorResponse } from '@/apis/apiInstance';
+import type { AxiosResponse } from 'axios';
+import { generatePath } from 'react-router-dom';
+
+export interface Review {
+  reviewId: string;
+  reviwerName: string;
+  festivalTitle: string;
+  content: string;
+  score: number;
+  imageUrls: string[];
+  videoUrl: string;
+}
+export const getReview = async (params: {
+  festivalId: string;
+}): Promise<AxiosResponse<ApiResponseList<Review>, ApiErrorResponse>> => {
+  return await apiInstance.get<ApiResponseList<Review>>(
+    generatePath(API_ENDPOINTS.FESTIVAL_REVIEWS, { festivalId: params.festivalId }),
+  );
+};
+
+export default getReview;

--- a/src/apis/wish/deleteWish.ts
+++ b/src/apis/wish/deleteWish.ts
@@ -1,0 +1,16 @@
+import { apiInstance } from '@/apis/apiInstance';
+import API_ENDPOINTS from '@/constants/apiEndpoints';
+import type { ApiErrorResponse } from '@/apis/apiInstance';
+import type { AxiosResponse } from 'axios';
+import { generatePath } from 'react-router-dom';
+
+// 삭제 되면 204 NO CONTENT 반환
+export const deleteWish = async (params: {
+  wishId: string;
+}): Promise<AxiosResponse<void, ApiErrorResponse>> => {
+  return await apiInstance.delete<void>(
+    generatePath(API_ENDPOINTS.FESTIVAL_WISH_DELETE, { wishId: params.wishId }),
+  );
+};
+
+export default deleteWish;

--- a/src/apis/wish/postWish.ts
+++ b/src/apis/wish/postWish.ts
@@ -1,0 +1,24 @@
+import { apiInstance } from '@/apis/apiInstance';
+import API_ENDPOINTS from '@/constants/apiEndpoints';
+import type { ApiErrorResponse } from '@/apis/apiInstance';
+import type { AxiosResponse } from 'axios';
+import { generatePath } from 'react-router-dom';
+
+export interface PostWishResponse {
+  content: {
+    wishId: string;
+    festivalId: string;
+    title: string;
+    areaCode: number;
+  };
+}
+
+export const postWish = async (params: {
+  festivalId: string;
+}): Promise<AxiosResponse<PostWishResponse, ApiErrorResponse>> => {
+  return await apiInstance.post<PostWishResponse>(
+    generatePath(API_ENDPOINTS.FESTIVAL_WISH, { festivalId: params.festivalId }),
+  );
+};
+
+export default postWish;

--- a/src/components/common/StarRating.tsx
+++ b/src/components/common/StarRating.tsx
@@ -58,7 +58,7 @@ const StarRating = ({ rating, maxRating = 5, size = 'md', showScore = false }: S
     <div className="flex items-center gap-1">
       <div className="flex items-center">{renderStars()}</div>
       {showScore && (
-        <span className={`${textSizeClasses[size]} text-gray-600 ml-1`}>({rating.toFixed(1)})</span>
+        <span className={`${textSizeClasses[size]} text-gray-600 ml-1`}>{rating.toFixed(1)}</span>
       )}
     </div>
   );

--- a/src/components/common/StarRating.tsx
+++ b/src/components/common/StarRating.tsx
@@ -1,0 +1,67 @@
+import StarIcon from '@/components/icon/StarIcon';
+
+interface StarRatingProps {
+  rating: number;
+  maxRating?: number;
+  size?: 'sm' | 'md' | 'lg';
+  showScore?: boolean;
+}
+
+/**
+ * StarRating 컴포넌트
+ * @param rating - 별점
+ * @param maxRating - 최대 별점(기본값: 5)
+ * @param size - 별점 크기(기본값: 'md')
+ * @param showScore - 별점 점수 표시 여부(기본값: false)
+ */
+const StarRating = ({ rating, maxRating = 5, size = 'md', showScore = false }: StarRatingProps) => {
+  const sizeClasses = {
+    sm: 'w-3 h-3',
+    md: 'w-4 h-4',
+    lg: 'w-5 h-5',
+  };
+
+  const textSizeClasses = {
+    sm: 'text-xs',
+    md: 'text-sm',
+    lg: 'text-base',
+  };
+
+  const renderStars = () => {
+    const stars = [];
+
+    for (let i = 1; i <= maxRating; i++) {
+      const isFilled = i <= rating;
+      const isHalfFilled = i - 0.5 === rating;
+
+      stars.push(
+        <div key={i} className="relative">
+          <StarIcon className={`${sizeClasses[size]} text-gray-300`} filled />
+
+          {(isFilled || isHalfFilled) && (
+            <StarIcon
+              className={`${sizeClasses[size]} text-yellow-400 absolute top-0 left-0 ${
+                isHalfFilled ? 'overflow-hidden' : ''
+              }`}
+              filled
+              style={isHalfFilled ? { clipPath: 'inset(0 50% 0 0)' } : {}}
+            />
+          )}
+        </div>,
+      );
+    }
+
+    return stars;
+  };
+
+  return (
+    <div className="flex items-center gap-1">
+      <div className="flex items-center">{renderStars()}</div>
+      {showScore && (
+        <span className={`${textSizeClasses[size]} text-gray-600 ml-1`}>({rating.toFixed(1)})</span>
+      )}
+    </div>
+  );
+};
+
+export default StarRating;

--- a/src/components/icon/RightArrowIcon.tsx
+++ b/src/components/icon/RightArrowIcon.tsx
@@ -1,0 +1,22 @@
+interface RightArrowProps {
+  className?: string;
+}
+
+const RightArrow = ({ className }: RightArrowProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={28}
+      height={28}
+      viewBox="0 0 24 24"
+      strokeWidth={3}
+      fill="none"
+      stroke="black"
+      className={className}
+    >
+      <path d="M8 4 L16 12 L8 20" />
+    </svg>
+  );
+};
+
+export default RightArrow;

--- a/src/components/icon/StarIcon.tsx
+++ b/src/components/icon/StarIcon.tsx
@@ -1,0 +1,23 @@
+interface StarIconProps {
+  className?: string;
+  filled?: boolean;
+  style?: React.CSSProperties;
+}
+
+const StarIcon = ({ className = '', filled = false, style }: StarIconProps) => {
+  return (
+    <svg
+      className={className}
+      fill={filled ? 'currentColor' : 'none'}
+      stroke={filled ? 'none' : 'currentColor'}
+      strokeWidth={filled ? 0 : 1}
+      viewBox="0 0 20 20"
+      xmlns="http://www.w3.org/2000/svg"
+      style={style}
+    >
+      <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
+    </svg>
+  );
+};
+
+export default StarIcon;

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -1,6 +1,8 @@
 const API_ENDPOINTS = {
   FESTIVALS: '/api/festivals/area/:areaId',
   FESTIVAL_INFO: '/api/festivals/:festivalId',
+  FESTIVAL_WISH: '/api/festivals/:festivalId/wishes',
+  FESTIVAL_WISH_DELETE: '/api/wishes/:wishId',
   // OAuth 로그인
   GOOGLE_LOGIN: '/oauth2/authorization/google',
   KAKAO_LOGIN: '/oauth2/authorization/kakao',

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -3,6 +3,7 @@ const API_ENDPOINTS = {
   FESTIVAL_INFO: '/api/festivals/:festivalId',
   FESTIVAL_WISH: '/api/festivals/:festivalId/wishes',
   FESTIVAL_WISH_DELETE: '/api/wishes/:wishId',
+  FESTIVAL_REVIEWS: '/api/festivals/:festivalId/reviews',
   // OAuth 로그인
   GOOGLE_LOGIN: '/oauth2/authorization/google',
   KAKAO_LOGIN: '/oauth2/authorization/kakao',

--- a/src/context/PickContext.tsx
+++ b/src/context/PickContext.tsx
@@ -1,6 +1,9 @@
 import { createContext, useContext, useState, type ReactNode, type ChangeEvent } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
+// 최대 선택 가능한 스타일 수
+const MAX_SELECTED_STYLES = 3;
+
 interface PickContextType {
   selectedStyles: string[];
   mbtiAnswers: Record<string, boolean>;
@@ -28,7 +31,7 @@ export const PickProvider = ({ children }: { children: ReactNode }) => {
         return prev.filter((id) => id !== styleId);
       }
 
-      if (prev.length < 3) {
+      if (prev.length < MAX_SELECTED_STYLES) {
         return [...prev, styleId];
       }
 

--- a/src/hooks/useNav.ts
+++ b/src/hooks/useNav.ts
@@ -1,4 +1,3 @@
-import { ROUTE_PATH } from '@/constants/routes';
 import { useNavigate } from 'react-router-dom';
 
 /**
@@ -6,25 +5,20 @@ import { useNavigate } from 'react-router-dom';
  * @description 단순하게 useNavigate를 사용하여 이동하는 경우 간편하게 사용할 수 있도록 만들었습니다.
  * @returns {Object}
  * - goBack: 뒤로가기 함수
- * - goHome: 홈으로 이동 함수
- * - goMy: 마이페이지로 이동 함수
- * - goSearch: 검색 페이지로 이동 함수
+ * - goTo(path: string): 지정된 경로로 이동하는 함수
  */
 const useNav = () => {
   const navigate = useNavigate();
+
   const goBack = () => {
     navigate(-1);
   };
-  const goHome = () => {
-    navigate(ROUTE_PATH.HOME);
+
+  const goTo = (path: string) => {
+    navigate(path);
   };
-  const goMy = () => {
-    navigate(ROUTE_PATH.MY);
-  };
-  const goSearch = () => {
-    navigate(ROUTE_PATH.SEARCH);
-  };
-  return { goBack, goHome, goMy, goSearch };
+
+  return { goBack, goTo };
 };
 
 export default useNav;

--- a/src/mocks/data/review.mock.ts
+++ b/src/mocks/data/review.mock.ts
@@ -2,7 +2,7 @@ export const reviewMockData = {
   content: [
     {
       reviewId: '1',
-      reviwerName: '홍길동',
+      reviewerName: '홍길동',
       festivalTitle: '가평 양떼목장 수국축제',
       content: '꽃이 예뻐요.',
       score: 5,
@@ -17,7 +17,7 @@ export const reviewMockData = {
     },
     {
       reviewId: '2',
-      reviwerName: '이영희',
+      reviewerName: '이영희',
       festivalTitle: '가평 양떼목장 수국축제',
       content: '행사가 재밌었어요.',
       score: 4,
@@ -32,7 +32,7 @@ export const reviewMockData = {
     },
     {
       reviewId: '3',
-      reviwerName: '박철수',
+      reviewerName: '박철수',
       festivalTitle: '가평 양떼목장 수국축제',
       content: '볼거리가 많았고 식사도 맛있었어요.',
       score: 4,

--- a/src/mocks/data/review.mock.ts
+++ b/src/mocks/data/review.mock.ts
@@ -1,0 +1,43 @@
+export const reviewMockData = {
+  content: [
+    {
+      reviewId: '1',
+      reviwerName: '홍길동',
+      festivalTitle: '가평 양떼목장 수국축제',
+      content: '꽃이 예뻐요.',
+      score: 5,
+      imageUrls: [
+        'http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg',
+      ],
+      videoUrl: '',
+    },
+    {
+      reviewId: '2',
+      reviwerName: '이영희',
+      festivalTitle: '가평 양떼목장 수국축제',
+      content: '행사가 재밌었어요.',
+      score: 4,
+      imageUrls: [
+        'http://tong.visitkorea.or.kr/cms/resource/82/3503882_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/83/3503883_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/84/3503884_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/85/3503885_image2_1.jpg',
+        'http://tong.visitkorea.or.kr/cms/resource/86/3503886_image2_1.jpg',
+      ],
+      videoUrl: 'https://video.com/2.mp4',
+    },
+    {
+      reviewId: '3',
+      reviwerName: '박철수',
+      festivalTitle: '가평 양떼목장 수국축제',
+      content: '볼거리가 많았고 식사도 맛있었어요.',
+      score: 4,
+      imageUrls: [],
+      videoUrl: '',
+    },
+  ],
+};

--- a/src/mocks/handlers/handlers.ts
+++ b/src/mocks/handlers/handlers.ts
@@ -1,4 +1,5 @@
 import { getFestivalsHandler } from '@/mocks/handlers/festivals/getFestivals.mock';
 import { getFestivalsInfoHandler } from '@/mocks/handlers/festivals/getFestivalsInfo.mock';
+import { getReviewHandler } from '@/mocks/handlers/review/getReview.mock';
 
-export const handlers = [...getFestivalsHandler, ...getFestivalsInfoHandler];
+export const handlers = [...getFestivalsHandler, ...getFestivalsInfoHandler, ...getReviewHandler];

--- a/src/mocks/handlers/review/getReview.mock.ts
+++ b/src/mocks/handlers/review/getReview.mock.ts
@@ -1,0 +1,28 @@
+import { apiBaseUrl } from '@/apis/apiInstance';
+import API_ENDPOINTS from '@/constants/apiEndpoints';
+import { reviewMockData } from '@/mocks/data/review.mock';
+import { http, HttpResponse } from 'msw';
+
+export const getReviewHandler = [
+  http.get<{ festivalId: string }>(
+    apiBaseUrl + API_ENDPOINTS.FESTIVAL_REVIEWS,
+    async ({ params }) => {
+      const { festivalId } = params;
+
+      if (!festivalId || festivalId === '0') {
+        return HttpResponse.json(
+          {
+            status: 'BAD_REQUEST',
+            statusCode: 400,
+            message: '존재하지 않는 축제입니다',
+          },
+          { status: 400 },
+        );
+      }
+
+      return HttpResponse.json({
+        ...reviewMockData,
+      });
+    },
+  ),
+];

--- a/src/pages/FestivalInfo/FestivalInfoPage.tsx
+++ b/src/pages/FestivalInfo/FestivalInfoPage.tsx
@@ -11,6 +11,7 @@ import FestivalContentInfoSection from '@/pages/FestivalInfo/components/Festival
 import FestivalContentOverviewSection from '@/pages/FestivalInfo/components/FestivalContentOverviewSection';
 import FestivalContentReviewSection from '@/pages/FestivalInfo/components/FestivalContentReviewSection';
 import Footer from '@/components/common/Footer';
+import getReview from '@/apis/review/getReview';
 
 const FestivalInfoPage = () => {
   const { festivalId } = useParams();
@@ -19,6 +20,12 @@ const FestivalInfoPage = () => {
     queryFn: () => getFestivalInfo({ festivalId: festivalId || '' }),
     select: (data) => data.data,
     enabled: !!festivalId,
+  });
+
+  const { data: reviewsData } = useQuery({
+    queryKey: ['reviews', festivalId],
+    queryFn: () => getReview({ festivalId: festivalId || '' }),
+    select: (data) => data.data,
   });
   // Todo:
   // 로딩,에러 페이지 통일하기
@@ -56,11 +63,11 @@ const FestivalInfoPage = () => {
         <div className="w-full h-full p-4 gap-4 flex flex-col">
           <FestivalBannerSection url={data.content.homePage} />
           <Divider height="1px" />
-          <FestivalContentInfoSection content={data.content} />
+          <FestivalContentInfoSection content={data.content} reviewsData={reviewsData?.content} />
           <Divider height="1px" />
           <FestivalContentOverviewSection overview={data.content.overView} />
           <Divider height="1px" />
-          <FestivalContentReviewSection festivalId={festivalId} />
+          <FestivalContentReviewSection reviewsData={reviewsData?.content} />
         </div>
       </div>
       <FestivalInfoFooter />

--- a/src/pages/FestivalInfo/FestivalInfoPage.tsx
+++ b/src/pages/FestivalInfo/FestivalInfoPage.tsx
@@ -67,7 +67,10 @@ const FestivalInfoPage = () => {
           <Divider height="1px" />
           <FestivalContentOverviewSection overview={data.content.overView} />
           <Divider height="1px" />
-          <FestivalContentReviewSection reviewsData={reviewsData?.content} />
+          <FestivalContentReviewSection
+            reviewsData={reviewsData?.content}
+            festivalTitle={data.content.title}
+          />
         </div>
       </div>
       <FestivalInfoFooter />

--- a/src/pages/FestivalInfo/FestivalInfoPage.tsx
+++ b/src/pages/FestivalInfo/FestivalInfoPage.tsx
@@ -19,6 +19,8 @@ const FestivalInfoPage = () => {
     select: (data) => data.data,
     enabled: !!festivalId,
   });
+  // Todo:
+  // 로딩,에러 페이지 통일하기
 
   if (isPending) {
     return (
@@ -45,7 +47,11 @@ const FestivalInfoPage = () => {
     <Container>
       <Header variant="all" />
       <div className="flex flex-col items-center w-full h-full">
-        <FestivalPoster imageUrl={data.content.posterInfo} title={data.content.title} />
+        <FestivalPoster
+          posterUrl={data.content.posterInfo}
+          imageUrls={data.content.imageInfos}
+          title={data.content.title}
+        />
         <div className="w-full h-full p-4 gap-4 flex flex-col">
           <FestivalBannerSection url={data.content.homePage} />
           <Divider height="1px" />

--- a/src/pages/FestivalInfo/FestivalInfoPage.tsx
+++ b/src/pages/FestivalInfo/FestivalInfoPage.tsx
@@ -9,6 +9,7 @@ import FestivalBannerSection from '@/pages/FestivalInfo/components/FestivalBanne
 import Divider from '@/components/common/Divider';
 import FestivalContentInfoSection from '@/pages/FestivalInfo/components/FestivalContentInfoSection';
 import FestivalContentOverviewSection from '@/pages/FestivalInfo/components/FestivalContentOverviewSection';
+import FestivalContentReviewSection from '@/pages/FestivalInfo/components/FestivalContentReviewSection';
 import Footer from '@/components/common/Footer';
 
 const FestivalInfoPage = () => {
@@ -31,7 +32,7 @@ const FestivalInfoPage = () => {
     );
   }
 
-  if (isError) {
+  if (isError || !festivalId) {
     return (
       <Container>
         <Header variant="page" />
@@ -58,6 +59,8 @@ const FestivalInfoPage = () => {
           <FestivalContentInfoSection content={data.content} />
           <Divider height="1px" />
           <FestivalContentOverviewSection overview={data.content.overView} />
+          <Divider height="1px" />
+          <FestivalContentReviewSection festivalId={festivalId} />
         </div>
       </div>
       <FestivalInfoFooter />

--- a/src/pages/FestivalInfo/components/FestivalContentInfoSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentInfoSection.tsx
@@ -2,11 +2,20 @@ import type { FestivalInfo } from '@/types/FestivalType';
 import FestivalContentTitle from '@/pages/FestivalInfo/components/FestivalContentTitle';
 import FestivalContentDuration from '@/pages/FestivalInfo/components/FestivalContentDuration';
 import FestivalContentAddress from '@/pages/FestivalInfo/components/FestivalContentAddress';
+import FestivalContentStarAndReveiwCount from '@/pages/FestivalInfo/components/FestivalContentStarAndReveiwCount';
+import type { Review } from '@/apis/review/getReview';
 
-const FestivalContentInfoSection = ({ content }: { content: FestivalInfo }) => {
+const FestivalContentInfoSection = ({
+  content,
+  reviewsData,
+}: {
+  content: FestivalInfo;
+  reviewsData: Review[] | undefined;
+}) => {
   return (
     <div className="w-full h-full flex flex-col gap-2">
       <FestivalContentTitle title={content.title} />
+      <FestivalContentStarAndReveiwCount reviewsData={reviewsData} />
       <FestivalContentDuration startDate={content.startDate} endDate={content.endDate} />
       <FestivalContentAddress address1={content.addr1} address2={content.addr2} />
     </div>

--- a/src/pages/FestivalInfo/components/FestivalContentInfoSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentInfoSection.tsx
@@ -2,7 +2,7 @@ import type { FestivalInfo } from '@/types/FestivalType';
 import FestivalContentTitle from '@/pages/FestivalInfo/components/FestivalContentTitle';
 import FestivalContentDuration from '@/pages/FestivalInfo/components/FestivalContentDuration';
 import FestivalContentAddress from '@/pages/FestivalInfo/components/FestivalContentAddress';
-import FestivalContentStarAndReveiwCount from '@/pages/FestivalInfo/components/FestivalContentStarAndReveiwCount';
+import FestivalContentStarAndReviewCount from '@/pages/FestivalInfo/components/FestivalContentStarAndReviewCount';
 import type { Review } from '@/apis/review/getReview';
 
 const FestivalContentInfoSection = ({
@@ -15,7 +15,7 @@ const FestivalContentInfoSection = ({
   return (
     <div className="w-full h-full flex flex-col gap-2">
       <FestivalContentTitle title={content.title} />
-      <FestivalContentStarAndReveiwCount reviewsData={reviewsData} />
+      <FestivalContentStarAndReviewCount reviewsData={reviewsData} />
       <FestivalContentDuration startDate={content.startDate} endDate={content.endDate} />
       <FestivalContentAddress address1={content.addr1} address2={content.addr2} />
     </div>

--- a/src/pages/FestivalInfo/components/FestivalContentReviewMediaModal.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewMediaModal.tsx
@@ -1,0 +1,161 @@
+import { useState, useRef } from 'react';
+import LeftArrow from '@/components/icon/LeftArrowIcon';
+import RightArrow from '@/components/icon/RightArrowIcon';
+
+interface MediaItem {
+  type: 'video' | 'image';
+  url: string;
+}
+
+interface FestivalContentReviewMediaModalProps {
+  mediaItems: MediaItem[];
+  selectedMediaIndex: number;
+  setSelectedMediaIndex: (index: number) => void;
+  onClose: () => void;
+  festivalTitle?: string;
+}
+
+// 드래그 임계값
+const SWIPE_THRESHOLD = 50;
+
+const FestivalContentReviewMediaModal = ({
+  mediaItems,
+  selectedMediaIndex,
+  setSelectedMediaIndex,
+  onClose,
+  festivalTitle,
+}: FestivalContentReviewMediaModalProps) => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [translateX, setTranslateX] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsDragging(true);
+    setStartX(e.touches[0].clientX);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+    const currentX = e.touches[0].clientX;
+    const diff = currentX - startX;
+    setTranslateX(diff);
+  };
+
+  const handleDragEnd = () => {
+    if (!isDragging) return;
+    const threshold = SWIPE_THRESHOLD;
+    if (Math.abs(translateX) > threshold) {
+      if (translateX > 0 && selectedMediaIndex > 0) {
+        setSelectedMediaIndex(selectedMediaIndex - 1);
+      } else if (translateX < 0 && selectedMediaIndex < mediaItems.length - 1) {
+        setSelectedMediaIndex(selectedMediaIndex + 1);
+      }
+    }
+    setIsDragging(false);
+    setTranslateX(0);
+  };
+
+  const arrowButtonClasses =
+    'absolute top-1/2 transform -translate-y-1/2 text-white w-12 h-12 rounded-full flex items-center justify-center transition-all duration-200 z-20 hidden md:flex';
+
+  return (
+    <div
+      className="fixed inset-0 bg-black flex items-center justify-center z-[1000]"
+      onClick={onClose}
+    >
+      <div className="relative w-full h-full max-w-[480px] p-4 flex items-center justify-center">
+        <div
+          ref={containerRef}
+          className="relative w-full h-full max-w-[480px] overflow-hidden"
+          onTouchStart={handleTouchStart}
+          onTouchMove={handleTouchMove}
+          onTouchEnd={handleDragEnd}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div
+            className="flex transition-transform duration-300 ease-out h-full"
+            style={{
+              transform: `translateX(${-selectedMediaIndex * 100 + (isDragging ? (translateX / (containerRef.current?.offsetWidth || 1)) * 100 : 0)}%)`,
+            }}
+          >
+            {mediaItems.map((item, index) => (
+              <div
+                key={index}
+                className="w-full h-full flex-shrink-0 flex items-center justify-center"
+              >
+                {item.type === 'video' ? (
+                  <div className="relative w-full h-full flex items-center justify-center bg-black">
+                    <video
+                      src={item.url}
+                      className="w-full h-full object-contain"
+                      controls
+                      playsInline
+                      preload="metadata"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                      }}
+                    />
+                  </div>
+                ) : (
+                  <img
+                    src={item.url}
+                    alt="확대된 리뷰 이미지"
+                    className="w-full h-full object-contain select-none"
+                    draggable={false}
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {mediaItems.length > 1 && (
+            <>
+              {selectedMediaIndex > 0 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedMediaIndex(selectedMediaIndex - 1);
+                  }}
+                  className={`${arrowButtonClasses} left-4`}
+                  aria-label="이전 미디어"
+                >
+                  <LeftArrow className="stroke-white" />
+                </button>
+              )}
+              {selectedMediaIndex < mediaItems.length - 1 && (
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedMediaIndex(selectedMediaIndex + 1);
+                  }}
+                  className={`${arrowButtonClasses} right-4`}
+                  aria-label="다음 미디어"
+                >
+                  <RightArrow className="stroke-white" />
+                </button>
+              )}
+            </>
+          )}
+
+          <div className="absolute top-0 left-0 flex items-center gap-3 z-20">
+            <button
+              onClick={onClose}
+              className="w-10 h-10 text-white rounded-full flex items-center justify-center transition-all text-xl cursor-pointer"
+              aria-label="모달 닫기"
+            >
+              ×
+            </button>
+            {festivalTitle && <h3 className="text-white text-lg font-medium">{festivalTitle}</h3>}
+          </div>
+
+          <div className="absolute bottom-4 right-4 text-white px-3 py-1 rounded-full text-sm z-20">
+            {selectedMediaIndex + 1} / {mediaItems.length}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FestivalContentReviewMediaModal;

--- a/src/pages/FestivalInfo/components/FestivalContentReviewMediaSlider.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewMediaSlider.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import type { Review } from '@/apis/review/getReview';
+import FestivalContentReviewMediaModal from './FestivalContentReviewMediaModal';
+
+const FestivalContentReviewMediaSlider = ({
+  review,
+  festivalTitle,
+}: {
+  review: Review;
+  festivalTitle: string;
+}) => {
+  const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+
+  const mediaItems = [
+    ...(review.videoUrl ? [{ type: 'video' as const, url: review.videoUrl }] : []),
+    ...(review.imageUrls.length > 0
+      ? review.imageUrls.map((url) => ({ type: 'image' as const, url }))
+      : []),
+  ];
+
+  if (mediaItems.length === 0) return null;
+
+  const handleMediaClick = (index: number) => {
+    setSelectedImageIndex(index);
+    setIsImageModalOpen(true);
+  };
+
+  return (
+    <>
+      <div className="relative w-full h-full">
+        <div className="flex overflow-x-scroll gap-2 pb-2 h-full md:pb-4">
+          {mediaItems.map((item, index) => (
+            <div key={index} className="relative flex-shrink-0 size-32 rounded-lg overflow-hidden">
+              {item.type === 'video' ? (
+                <div className="relative w-full h-full">
+                  <video
+                    src={item.url}
+                    className="w-full h-full object-cover"
+                    onClick={() => handleMediaClick(index)}
+                  />
+                  <div
+                    className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 transition-all cursor-pointer"
+                    onClick={() => handleMediaClick(index)}
+                  >
+                    <div className="w-12 h-12 bg-black bg-opacity-60 rounded-full flex items-center justify-center">
+                      <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 24 24"
+                        fill="none"
+                        className="text-white ml-1"
+                      >
+                        <path d="M8 5v14l11-7z" fill="currentColor" />
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <img
+                  src={item.url}
+                  alt="리뷰 이미지"
+                  className="w-full h-full object-cover cursor-pointer transition-transform"
+                  onClick={() => handleMediaClick(index)}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {isImageModalOpen && (
+        <FestivalContentReviewMediaModal
+          mediaItems={mediaItems}
+          selectedMediaIndex={selectedImageIndex}
+          setSelectedMediaIndex={setSelectedImageIndex}
+          onClose={() => setIsImageModalOpen(false)}
+          festivalTitle={festivalTitle}
+        />
+      )}
+    </>
+  );
+};
+
+export default FestivalContentReviewMediaSlider;

--- a/src/pages/FestivalInfo/components/FestivalContentReviewMediaSlider.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewMediaSlider.tsx
@@ -40,16 +40,16 @@ const FestivalContentReviewMediaSlider = ({
                     onClick={() => handleMediaClick(index)}
                   />
                   <div
-                    className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30 transition-all cursor-pointer"
+                    className="absolute inset-0 flex items-center justify-center bg-black/30 transition-all cursor-pointer"
                     onClick={() => handleMediaClick(index)}
                   >
-                    <div className="w-12 h-12 bg-black bg-opacity-60 rounded-full flex items-center justify-center">
+                    <div className="size-10 bg-black/60 rounded-full flex items-center justify-center">
                       <svg
                         width="16"
                         height="16"
                         viewBox="0 0 24 24"
                         fill="none"
-                        className="text-white ml-1"
+                        className="text-white"
                       >
                         <path d="M8 5v14l11-7z" fill="currentColor" />
                       </svg>

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import getReview from '@/apis/review/getReview';
+import StarRating from '@/components/common/StarRating';
+
+interface FestivalContentReviewSectionProps {
+  festivalId: string;
+}
+
+const FestivalContentReviewSection = ({ festivalId }: FestivalContentReviewSectionProps) => {
+  const { data } = useQuery({
+    queryKey: ['reviews', festivalId],
+    queryFn: () => getReview({ festivalId: festivalId }),
+    select: (data) => data.data,
+  });
+
+  if (!data) return null;
+
+  if (data.content.length === 0) {
+    return (
+      <div className="w-full h-full flex flex-col gap-2">
+        <h3 className="text-sm text-gray-900 font-bold">리뷰</h3>
+        <p className="text-sm text-gray-700">리뷰가 없습니다.</p>
+      </div>
+    );
+  }
+  return (
+    <div className="w-full h-full flex flex-col gap-2">
+      <h3 className="text-sm text-gray-900 font-bold">리뷰 ({data?.content.length})</h3>
+      {data.content.map((review) => (
+        <div key={review.reviewId} className="p-3 border border-gray-200 rounded-lg">
+          <div className="flex items-center justify-between mb-2">
+            <p className="font-medium text-gray-900">{review.reviwerName}</p>
+            <StarRating rating={review.score} />
+          </div>
+          <p className="text-sm text-gray-700">{review.content}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default FestivalContentReviewSection;

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -1,11 +1,16 @@
 import StarRating from '@/components/common/StarRating';
 import type { Review } from '@/apis/review/getReview';
+import FestivalContentReviewMediaSlider from './FestivalContentReviewMediaSlider';
 
 interface FestivalContentReviewSectionProps {
   reviewsData: Review[] | undefined;
+  festivalTitle: string;
 }
 
-const FestivalContentReviewSection = ({ reviewsData }: FestivalContentReviewSectionProps) => {
+const FestivalContentReviewSection = ({
+  reviewsData,
+  festivalTitle,
+}: FestivalContentReviewSectionProps) => {
   if (!reviewsData) return null;
   if (reviewsData.length === 0) {
     return (
@@ -19,11 +24,17 @@ const FestivalContentReviewSection = ({ reviewsData }: FestivalContentReviewSect
     <div className="w-full h-full flex flex-col gap-2">
       <h3 className="text-sm text-gray-900 font-bold">리뷰 ({reviewsData.length})</h3>
       {reviewsData.map((review) => (
-        <div key={review.reviewId} className="p-3 border border-gray-200 rounded-lg">
-          <div className="flex items-center justify-between mb-2">
+        <div
+          key={review.reviewId}
+          className="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
+        >
+          <div className="flex items-center justify-between">
             <p className="font-medium text-gray-900">{review.reviwerName}</p>
             <StarRating rating={review.score} />
           </div>
+
+          <FestivalContentReviewMediaSlider review={review} festivalTitle={festivalTitle} />
+
           <p className="text-sm text-gray-700">{review.content}</p>
         </div>
       ))}

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -1,32 +1,24 @@
-import { useQuery } from '@tanstack/react-query';
-import getReview from '@/apis/review/getReview';
 import StarRating from '@/components/common/StarRating';
+import type { Review } from '@/apis/review/getReview';
 
 interface FestivalContentReviewSectionProps {
-  festivalId: string;
+  reviewsData: Review[] | undefined;
 }
 
-const FestivalContentReviewSection = ({ festivalId }: FestivalContentReviewSectionProps) => {
-  const { data } = useQuery({
-    queryKey: ['reviews', festivalId],
-    queryFn: () => getReview({ festivalId: festivalId }),
-    select: (data) => data.data,
-  });
-
-  if (!data) return null;
-
-  if (data.content.length === 0) {
+const FestivalContentReviewSection = ({ reviewsData }: FestivalContentReviewSectionProps) => {
+  if (!reviewsData) return null;
+  if (reviewsData.length === 0) {
     return (
       <div className="w-full h-full flex flex-col gap-2">
         <h3 className="text-sm text-gray-900 font-bold">리뷰</h3>
-        <p className="text-sm text-gray-700">리뷰가 없습니다.</p>
+        <p className="text-sm text-gray-700">첫 번째 리뷰의 주인공이 되어보세요!</p>
       </div>
     );
   }
   return (
     <div className="w-full h-full flex flex-col gap-2">
-      <h3 className="text-sm text-gray-900 font-bold">리뷰 ({data?.content.length})</h3>
-      {data.content.map((review) => (
+      <h3 className="text-sm text-gray-900 font-bold">리뷰 ({reviewsData.length})</h3>
+      {reviewsData.map((review) => (
         <div key={review.reviewId} className="p-3 border border-gray-200 rounded-lg">
           <div className="flex items-center justify-between mb-2">
             <p className="font-medium text-gray-900">{review.reviwerName}</p>

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -29,7 +29,7 @@ const FestivalContentReviewSection = ({
           className="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
         >
           <div className="flex items-center justify-between">
-            <p className="font-medium text-gray-900">{review.reviwerName}</p>
+            <p className="font-medium text-gray-900">{review.reviewerName}</p>
             <StarRating rating={review.score} />
           </div>
 

--- a/src/pages/FestivalInfo/components/FestivalContentStarAndReveiwCount.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentStarAndReveiwCount.tsx
@@ -1,0 +1,24 @@
+import StarRating from '@/components/common/StarRating';
+import type { Review } from '@/apis/review/getReview';
+
+const FestivalContentStarAndReveiwCount = ({
+  reviewsData,
+}: {
+  reviewsData: Review[] | undefined;
+}) => {
+  if (!reviewsData) return null;
+  return (
+    <div className="flex items-center gap-2 text-sm text-gray-700">
+      <StarRating
+        rating={
+          reviewsData?.reduce((acc, review) => acc + review.score, 0) / reviewsData?.length || 0
+        }
+        showScore
+      />
+      <div className="w-px h-3 bg-gray-500" />
+      <p>리뷰 {reviewsData?.length}건</p>
+    </div>
+  );
+};
+
+export default FestivalContentStarAndReveiwCount;

--- a/src/pages/FestivalInfo/components/FestivalContentStarAndReviewCount.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentStarAndReviewCount.tsx
@@ -1,7 +1,7 @@
 import StarRating from '@/components/common/StarRating';
 import type { Review } from '@/apis/review/getReview';
 
-const FestivalContentStarAndReveiwCount = ({
+const FestivalContentStarAndReviewCount = ({
   reviewsData,
 }: {
   reviewsData: Review[] | undefined;
@@ -21,4 +21,4 @@ const FestivalContentStarAndReveiwCount = ({
   );
 };
 
-export default FestivalContentStarAndReveiwCount;
+export default FestivalContentStarAndReviewCount;

--- a/src/pages/FestivalInfo/components/FestivalPoster.tsx
+++ b/src/pages/FestivalInfo/components/FestivalPoster.tsx
@@ -1,5 +1,127 @@
-const FestivalPoster = ({ imageUrl, title }: { imageUrl: string; title: string }) => {
-  return <img src={imageUrl} alt={title} className="w-full h-full object-cover" />;
+import LeftArrow from '@/components/icon/LeftArrowIcon';
+import RightArrow from '@/components/icon/RightArrowIcon';
+import { useState, useRef } from 'react';
+
+// 슬라이드 전환 임계값
+const SWIPE_THRESHOLD = 50;
+
+const FestivalPoster = ({
+  posterUrl,
+  imageUrls,
+  title,
+}: {
+  posterUrl: string;
+  imageUrls: string[];
+  title: string;
+}) => {
+  const allImages = [posterUrl, ...imageUrls];
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const [startX, setStartX] = useState(0);
+  const [translateX, setTranslateX] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    setIsDragging(true);
+    setStartX(e.touches[0].clientX);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+
+    const currentX = e.touches[0].clientX;
+    const diff = currentX - startX;
+    setTranslateX(diff);
+  };
+
+  const handleDragEnd = () => {
+    if (!isDragging) return;
+
+    const threshold = SWIPE_THRESHOLD;
+
+    if (Math.abs(translateX) > threshold) {
+      if (translateX > 0 && currentIndex > 0) {
+        setCurrentIndex(currentIndex - 1);
+      } else if (translateX < 0 && currentIndex < allImages.length - 1) {
+        setCurrentIndex(currentIndex + 1);
+      }
+    }
+
+    setIsDragging(false);
+    setTranslateX(0);
+  };
+
+  const arrowButtonClasses =
+    'absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex';
+
+  return (
+    <div className="w-full relative">
+      <div
+        ref={containerRef}
+        className="relative w-full h-[500px] overflow-hidden"
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleDragEnd}
+      >
+        <div
+          className="flex transition-transform duration-300 ease-out h-full"
+          style={{
+            transform: `translateX(${-currentIndex * 100 + (isDragging ? (translateX / (containerRef.current?.offsetWidth || 1)) * 100 : 0)}%)`,
+          }}
+        >
+          {allImages.map((imageUrl, index) => (
+            <div key={index} className="w-full h-full flex-shrink-0">
+              <img
+                src={imageUrl}
+                alt={`${title} - ${index + 1}`}
+                className="w-full h-full object-contain select-none bg-gray-50"
+                draggable={false}
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* 데스크탑 화면일 때만 보입니다. */}
+        {allImages.length > 1 && (
+          <>
+            {currentIndex > 0 && (
+              <button
+                onClick={() => setCurrentIndex(currentIndex - 1)}
+                className={`${arrowButtonClasses} left-4`}
+                aria-label="이전 이미지"
+              >
+                <LeftArrow className="stroke-white" />
+              </button>
+            )}
+
+            {currentIndex < allImages.length - 1 && (
+              <button
+                onClick={() => setCurrentIndex(currentIndex + 1)}
+                className={`${arrowButtonClasses} right-4`}
+                aria-label="다음 이미지"
+              >
+                <RightArrow className="stroke-white" />
+              </button>
+            )}
+          </>
+        )}
+      </div>
+
+      {allImages.length > 1 && (
+        <div className="flex justify-center mt-2 gap-1">
+          {allImages.map((imageUrl, index) => (
+            <button
+              key={imageUrl}
+              onClick={() => setCurrentIndex(index)}
+              className={`w-2 h-2 rounded-full transition-colors ${
+                index === currentIndex ? 'bg-primary-300' : 'bg-gray-300'
+              }`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default FestivalPoster;

--- a/src/pages/FestivalInfo/components/FestivalWish.tsx
+++ b/src/pages/FestivalInfo/components/FestivalWish.tsx
@@ -1,6 +1,8 @@
 import Heart from '@/components/icon/HeartIcon';
 
 const FestivalWish = () => {
+  // Todo:
+  // 축제 찜 기능 추가
   return (
     <div>
       <Heart />

--- a/src/pages/FestivalInfo/components/FestivalWish.tsx
+++ b/src/pages/FestivalInfo/components/FestivalWish.tsx
@@ -1,11 +1,44 @@
 import Heart from '@/components/icon/HeartIcon';
+import { postWish } from '@/apis/wish/postWish';
+import { deleteWish } from '@/apis/wish/deleteWish';
+import { useMutation } from '@tanstack/react-query';
+import { useParams } from 'react-router-dom';
+import { useState } from 'react';
 
 const FestivalWish = () => {
   // Todo:
-  // 축제 찜 기능 추가
+  // 축제 찜 여부 조회 api 연결
+  // 축제 찜 여부 조회 api 연결 후 wishId 받아오기
+  const wishId = 1;
+  const [isWish, setIsWish] = useState(false);
+  const { festivalId } = useParams();
+  const { mutate: postWishMutation } = useMutation({
+    mutationFn: () => postWish({ festivalId: festivalId || '' }),
+    onSuccess: () => {
+      setIsWish(true);
+    },
+    onError: () => {
+      setIsWish(false);
+    },
+  });
+  const { mutate: deleteWishMutation } = useMutation({
+    // Todo:
+    // wishId 타입 수정
+    mutationFn: () => deleteWish({ wishId: wishId.toString() }),
+    onSuccess: () => {
+      setIsWish(false);
+    },
+    onError: () => {
+      setIsWish(true);
+    },
+  });
+
   return (
-    <div>
-      <Heart />
+    <div
+      onClick={() => (isWish ? deleteWishMutation() : postWishMutation())}
+      className="cursor-pointer"
+    >
+      <Heart fill={isWish} />
     </div>
   );
 };


### PR DESCRIPTION
지금 PR은 피어리뷰를 위해 최대한 기능에 집중하였고 다음 PR에서 테스트에 대한 전반적인 수정을 할 예정입니다. (스냅샷 파일 분리, 구조 변경)

- 코드 리뷰 리팩토링
  - PickPage 스타일 최대 선택 개수 상수 분리
  - useNav 훅 goTo 함수로 간결화
- FestivalInfoPage 고도화
  - Poster에 2개 이상의 이미지 보기 추가
  - Wish 추가 삭제 가능(Wish 불러오기 api에 대한 수정이 필요하여 추가 삭제만 추가하였습니다)
  - 리뷰 불러오기 추가
    - 이미지 추가 및 동영상 우선표시
  - 테스트 추가

멘토님이 남겨두신 테스트에 관한 방법론을 읽었을 때 스냅샷 테스트를 더 세분화하고 그에 따라 테스트 폴더 구조 변경이 필요하다고 생각하게 되었습니다. 

테스트를 세분화하게 되면 동일한 페이지에 다양한 컴포넌트를 분리하여 테스트하는데 한 폴더 내에 테스트 파일이 있을 경우 구분하기 어려워질 것이라고 생각합니다. 따라서 폴더 구조 변경에 대해 의논하고 싶습니다.

위와 비슷한 이유로 FestivalInfoPage에 컴포넌트를 쪼개는 과정에서 너무 많은 컴포넌트 파일이 생성되었습니다. 저는 여기서 더 분리하고 싶었지만 파일에 대한 관리가 어려워질 것 같아 어느 정도에서 멈추었습니다. 이에 관련해서도 관련 의견을 듣고 싶습니다.
