### PR TITLE
채팅방 나가기 기능 및 사용자 로직 개선

### DIFF
--- a/src/__tests__/TestWrapper.tsx
+++ b/src/__tests__/TestWrapper.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { AuthProvider } from '@/context/AuthContext';
+import { WebSocketProvider } from '@/context/WebSocketContext';
 
 const TestWrapper = ({
   children,
@@ -25,9 +26,11 @@ const TestWrapper = ({
   });
   return (
     <AuthProvider>
-      <MemoryRouter initialEntries={initialEntries}>
-        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-      </MemoryRouter>
+      <WebSocketProvider>
+        <MemoryRouter initialEntries={initialEntries}>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </MemoryRouter>
+      </WebSocketProvider>
     </AuthProvider>
   );
 };

--- a/src/__tests__/pages/FestivalInfoPage.test.tsx
+++ b/src/__tests__/pages/FestivalInfoPage.test.tsx
@@ -429,8 +429,8 @@ describe('FestivalPoster 컴포넌트', () => {
       const prevButton = screen.getByLabelText('이전 이미지');
       const nextButton = screen.getByLabelText('다음 이미지');
 
-      expect(prevButton).toHaveClass('hidden', 'md:flex');
-      expect(nextButton).toHaveClass('hidden', 'md:flex');
+      expect(prevButton).toHaveClass('hidden', 'sm:flex');
+      expect(nextButton).toHaveClass('hidden', 'sm:flex');
     });
   });
 });
@@ -574,9 +574,9 @@ describe('리뷰 섹션 컴포넌트', () => {
     expect(videoEl).toBeTruthy();
     videoEl && fireEvent.click(videoEl);
 
-    // Then: 모달이 열리고 화살표는 hidden md:flex 클래스를 가진다
+    // Then: 모달이 열리고 화살표는 hidden sm:flex 클래스를 가진다
     const nextBtn = await screen.findByLabelText('다음 미디어');
-    expect(nextBtn).toHaveClass('hidden', 'md:flex');
+    expect(nextBtn).toHaveClass('hidden', 'sm:flex');
     expect(screen.getByText(/\d+ \/ \d+/)).toBeInTheDocument();
 
     // And: 모달 닫기 가능

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 네비게이션 버튼 스냅샷 > next-button 1`] = `
 <button
   aria-label="다음 이미지"
-  class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex right-4"
+  class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden sm:flex right-4"
 >
   <svg
     class="stroke-white"
@@ -25,7 +25,7 @@ exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 네비게이션 버
 exports[`FestivalPoster 컴포넌트 > 스냅샷 테스트 > 네비게이션 버튼 스냅샷 > prev-button 1`] = `
 <button
   aria-label="이전 이미지"
-  class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex left-4"
+  class="absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden sm:flex left-4"
 >
   <svg
     class="stroke-white"

--- a/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
             />
           </svg>
           <span
-            class="text-sm sm:text-xs  text-gray-700"
+            class="text-sm sm:text-xs text-gray-700"
           >
             -
           </span>
@@ -153,7 +153,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
             />
           </svg>
           <span
-            class="text-sm sm:text-xs  text-gray-700"
+            class="text-sm sm:text-xs text-gray-700"
           >
             -
           </span>
@@ -246,7 +246,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천이 없을 때
             />
           </svg>
           <span
-            class="text-sm sm:text-xs  text-gray-700"
+            class="text-sm sm:text-xs text-gray-700"
           >
             -
           </span>

--- a/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
@@ -39,6 +39,57 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
       >
         경상북도 안동시
       </p>
+      <div
+        class="flex items-center gap-2 justify-end font-bold"
+      >
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            class="text-gray-300 size-4"
+            fill="currentColor"
+            stroke="none"
+            stroke-width="0"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs  text-gray-700"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart size-3"
+            fill="#fa342c"
+            height="20"
+            stroke="#fa342c"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs text-gray-700"
+          >
+            0
+          </span>
+        </div>
+      </div>
     </div>
   </div>
 </a>
@@ -83,6 +134,55 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
       >
         전북특별자치도 전주시
       </p>
+      <div
+        class="flex items-center gap-2 justify-end font-bold"
+      >
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            class="text-yellow-400 size-4"
+            fill="currentColor"
+            stroke="none"
+            stroke-width="0"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs  text-gray-700"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart size-3"
+            fill="#fa342c"
+            height="20"
+            stroke="#fa342c"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs text-gray-700"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </a>
@@ -127,6 +227,55 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천이 없을 때
       >
         전북특별자치도 전주시
       </p>
+      <div
+        class="flex items-center gap-2 justify-end font-bold"
+      >
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            class="text-yellow-400 size-4"
+            fill="currentColor"
+            stroke="none"
+            stroke-width="0"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs  text-gray-700"
+          >
+            -
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart size-3"
+            fill="#fa342c"
+            height="20"
+            stroke="#fa342c"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.5"
+            viewBox="0 0 24 24"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"
+            />
+          </svg>
+          <span
+            class="text-sm sm:text-xs text-gray-700"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </a>

--- a/src/apis/chat/deleteChatRoom.ts
+++ b/src/apis/chat/deleteChatRoom.ts
@@ -1,0 +1,14 @@
+import { apiInstance, type ApiErrorResponse } from '@/apis/apiInstance';
+import API_ENDPOINTS from '@/constants/apiEndpoints';
+import type { AxiosResponse } from 'axios';
+import { generatePath } from 'react-router-dom';
+
+export const deleteChatRoom = async (
+  roomId: number,
+): Promise<AxiosResponse<void, ApiErrorResponse>> => {
+  return await apiInstance.delete<void>(
+    generatePath(API_ENDPOINTS.LEAVE_CHAT_ROOM, { roomId: roomId.toString() }),
+  );
+};
+
+export default deleteChatRoom;

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -7,10 +7,12 @@ import useNav from '@/hooks/useNav';
 import { ROUTE_PATH } from '@/constants/routes';
 import { Link, useNavigate } from 'react-router-dom';
 import Settings from '@/components/icon/SettingIcon';
+import Leave from '@/components/icon/LeaveIcon';
 
 export interface HeaderProps {
-  variant?: 'logo' | 'page' | 'all' | 'mypage';
+  variant?: 'logo' | 'page' | 'all' | 'mypage' | 'chat';
   title?: string;
+  onClick?: () => void;
 }
 
 /**
@@ -21,8 +23,9 @@ export interface HeaderProps {
  *   - all: 뒤로가기, 제목, 홈/프로필 버튼을 모두 표시
  *   - mypage: 뒤로가기, 제목, 설정 버튼을 표시
  * @param title - 페이지 제목 (variant가 'page' 또는 'all'일 때 사용)
+ * @param onClick - 버튼 이벤트 (variant가 'mypage' 또는 'chat'일 때 사용)
  */
-const Header = ({ variant = 'logo', title = '' }: HeaderProps) => {
+const Header = ({ variant = 'logo', title = '', onClick }: HeaderProps) => {
   const containerClasses =
     'w-full mx-auto flex flex-col items-center fixed top-0 left-0 z-999 bg-gray-100';
   const baseClasses =
@@ -40,7 +43,7 @@ const Header = ({ variant = 'logo', title = '' }: HeaderProps) => {
       </div>
     );
   }
-  if (variant === 'mypage') {
+  if (variant === 'mypage' || variant === 'chat') {
     return (
       <div className={containerClasses}>
         <div className={`${baseClasses} justify-between`}>
@@ -50,17 +53,25 @@ const Header = ({ variant = 'logo', title = '' }: HeaderProps) => {
             </Button>
           </div>
           <div className="flex-2 flex justify-center">
-            <h1 className="text-md font-bold text-center">{'마이페이지'}</h1>
+            <h1 className="text-md font-bold text-center">
+              {variant === 'mypage' ? '마이페이지' : title}
+            </h1>
           </div>
           <div className="flex-1 flex justify-end">
-            <Link to={ROUTE_PATH.SETTINGS}>
-              <Button
-                variant="icon"
-                className="h-6 w-6 !p-0 rounded-lg flex items-center justify-center mr-5"
-              >
-                <Settings className="size-7" strokeWidth={2} />
+            {variant === 'mypage' ? (
+              <Link to={ROUTE_PATH.SETTINGS}>
+                <Button
+                  variant="icon"
+                  className="h-6 w-6 !p-0 rounded-lg flex items-center justify-center mr-5"
+                >
+                  <Settings className="size-7" strokeWidth={2} />
+                </Button>
+              </Link>
+            ) : (
+              <Button variant="icon" onClick={onClick}>
+                <Leave className="size-6" />
               </Button>
-            </Link>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/icon/HeartIcon.tsx
+++ b/src/components/icon/HeartIcon.tsx
@@ -1,9 +1,10 @@
 interface HeartProps {
   fill?: boolean;
   color?: string;
+  className?: string;
 }
 
-const Heart = ({ fill = false, color = '#fa342c' }: HeartProps) => {
+const Heart = ({ fill = false, color = '#fa342c', className = '' }: HeartProps) => {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -15,7 +16,7 @@ const Heart = ({ fill = false, color = '#fa342c' }: HeartProps) => {
       strokeWidth="1.5"
       strokeLinecap="round"
       strokeLinejoin="round"
-      className="lucide lucide-heart"
+      className={`lucide lucide-heart ${className}`}
       aria-hidden="true"
     >
       <path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"></path>

--- a/src/components/icon/LeaveIcon.tsx
+++ b/src/components/icon/LeaveIcon.tsx
@@ -1,0 +1,40 @@
+const Leave = ({ className, strokeWidth = 3 }: { className?: string; strokeWidth?: number }) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      className={className}
+    >
+      <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
+        <g>
+          <rect fillRule="nonzero" x="0" y="0" width="24" height="24" />
+          <line
+            stroke="currentColor"
+            x1="9"
+            y1="12"
+            x2="19"
+            y2="12"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+          />
+          <path
+            d="M16,8 L18.5858,10.5858 C19.3668,11.3668 19.3668,12.6332 18.5858,13.4142 L16,16"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+          />
+          <path
+            d="M16,4 L6,4 C4.89543,4 4,4.89543 4,6 L4,18 C4,19.1046 4.89543,20 6,20 L16,20"
+            stroke="currentColor"
+            strokeWidth={strokeWidth}
+            strokeLinecap="round"
+          />
+        </g>
+      </g>
+    </svg>
+  );
+};
+
+export default Leave;

--- a/src/components/modal/ImageModal.tsx
+++ b/src/components/modal/ImageModal.tsx
@@ -46,7 +46,7 @@ const ImageModal = ({ mediaItems, selectedMediaIndex, onClose, title }: ImageMod
   });
 
   const arrowButtonClasses =
-    'absolute top-1/2 transform -translate-y-1/2 text-white w-12 h-12 rounded-full flex items-center justify-center transition-all duration-200 z-20 hidden md:flex';
+    'absolute top-1/2 transform -translate-y-1/2 text-white w-12 h-12 rounded-full flex items-center justify-center transition-all duration-200 z-20 hidden sm:flex';
 
   return (
     <div

--- a/src/constants/apiEndpoints.ts
+++ b/src/constants/apiEndpoints.ts
@@ -25,6 +25,8 @@ const API_ENDPOINTS = {
   DELETE_USER: '/api/users',
   // 내가 참여한 채팅 방 조회
   MY_CHATS: '/api/chatRooms/me',
+  // 채팅 방 나가기
+  LEAVE_CHAT_ROOM: '/api/chatRooms/:roomId/me',
   // 내가 좋아요한 축제 목록 조회
   MY_WISHES_FESTIVAL: '/api/festivals/wishedBy/me',
   // 내가 작성한 리뷰의 축제 목록 조회

--- a/src/context/WebSocketContext.tsx
+++ b/src/context/WebSocketContext.tsx
@@ -32,6 +32,7 @@ interface WebSocketContextType {
   unsubscribe: (destination: string) => void;
   send: (destination: string, message: string) => void;
   disconnect: () => void;
+  getUnsubscribedChatRoomId: () => number | null;
 }
 
 const WebSocketContext = createContext<WebSocketContextType | undefined>(undefined);
@@ -62,6 +63,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       }
     >(),
   );
+  const unsubscribedChatRoomIdRef = useRef<number | null>(null);
   // 구독이 0개일 때 즉시 종료하지 않고 잠시 대기 후 종료하기 위한 타이머
   const NO_SUBS_GRACE_MS = 1200;
   const pendingDisconnectTimerRef = useRef<number | null>(null);
@@ -81,7 +83,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
             heartbeatIncoming: STOMP_CONFIG.HEARTBEAT_INCOMING_MS,
             heartbeatOutgoing: STOMP_CONFIG.HEARTBEAT_OUTGOING_MS,
             // 디버그 로그
-            // debug: (msg: string) => console.log('[STOMP]:', msg),
+            debug: (msg: string) => console.log('[STOMP]:', msg),
           });
 
           stompClient.onConnect = () => {
@@ -159,6 +161,12 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     const entry = destinationEntriesRef.current.get(destination);
     if (!entry) return;
 
+    // 채팅방 구독 해제 시 채팅방 ID 저장
+    const chatRoomIdMatch = destination.match(/^\/sub\/(\d+)\/messages$/);
+    if (chatRoomIdMatch) {
+      unsubscribedChatRoomIdRef.current = Number.parseInt(chatRoomIdMatch[1], 10);
+    }
+
     // 항상 destination 전체를 해제 (단일 컴포넌트만 하나의 destination을 구독한다고 가정)
     entry.handlers.clear();
     entry.refCount = 0;
@@ -185,6 +193,10 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         }
       }, NO_SUBS_GRACE_MS);
     }
+  };
+
+  const getUnsubscribedChatRoomId = () => {
+    return unsubscribedChatRoomIdRef.current;
   };
 
   const send = (destination: string, message: string) => {
@@ -228,6 +240,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const value: WebSocketContextType = {
     clientRef,
     subscriptionsRef,
+    getUnsubscribedChatRoomId,
     connectWebSocket,
     subscribe,
     unsubscribe,

--- a/src/context/WebSocketContext.tsx
+++ b/src/context/WebSocketContext.tsx
@@ -83,7 +83,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
             heartbeatIncoming: STOMP_CONFIG.HEARTBEAT_INCOMING_MS,
             heartbeatOutgoing: STOMP_CONFIG.HEARTBEAT_OUTGOING_MS,
             // 디버그 로그
-            debug: (msg: string) => console.log('[STOMP]:', msg),
+            // debug: (msg: string) => console.log('[STOMP]:', msg),
           });
 
           stompClient.onConnect = () => {
@@ -105,9 +105,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
             resolve();
           };
 
-          stompClient.onStompError = () => {
-            showToastErrorMessage(SYSTEM_MESSAGES.DEFAULT_ERROR_MESSAGES.NETWORK_ERROR);
-            reject(new Error('STOMP Error'));
+          stompClient.onStompError = (error) => {
+            console.error('STOMP Error', error);
           };
 
           stompClient.activate();

--- a/src/context/WebSocketContext.tsx
+++ b/src/context/WebSocketContext.tsx
@@ -17,6 +17,8 @@ export const STOMP_CONFIG = {
   HEARTBEAT_INCOMING_MS: 1000 * 15,
   // 하트비트 송신 딜레이(송신이 없을 때 연결 이상으로 판단)
   HEARTBEAT_OUTGOING_MS: 1000 * 15,
+  // 연결 타임아웃
+  CONNECTION_TIMEOUT_MS: 1000 * 30,
 } as const;
 
 /**
@@ -74,14 +76,16 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         try {
           const token = await getCurrentToken();
           if (!token) throw new Error('토큰이 없습니다.');
-
-          const socket = new SockJS(STOMP_URL);
+          const socket = new SockJS(STOMP_URL, null, {
+            transports: ['websocket', 'xhr-polling'],
+          });
           const stompClient = new Client({
             webSocketFactory: () => socket,
             connectHeaders: { Authorization: `Bearer ${token}` },
             reconnectDelay: STOMP_CONFIG.RECONNECT_DELAY_MS,
             heartbeatIncoming: STOMP_CONFIG.HEARTBEAT_INCOMING_MS,
             heartbeatOutgoing: STOMP_CONFIG.HEARTBEAT_OUTGOING_MS,
+            connectionTimeout: STOMP_CONFIG.CONNECTION_TIMEOUT_MS,
             // 디버그 로그
             // debug: (msg: string) => console.log('[STOMP]:', msg),
           });
@@ -90,7 +94,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
             clientRef.current = stompClient;
             // 재연결 시 기존 목적지 재구독
             for (const [destination, entry] of destinationEntriesRef.current.entries()) {
-              if (entry.refCount > 0) {
+              try {
                 entry.subscription = stompClient.subscribe(
                   destination,
                   (message) => {
@@ -100,6 +104,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
                   },
                   { id: `sub-${destination}`, ack: 'auto' },
                 );
+              } catch (e) {
+                console.error('STOMP Subscribe Error', e);
               }
             }
             resolve();

--- a/src/hooks/useChatRead.ts
+++ b/src/hooks/useChatRead.ts
@@ -11,7 +11,7 @@ const READ_TOPIC = '/user/queue/reads';
 
 const useChatRead = () => {
   const queryClient = useQueryClient();
-  const { connectWebSocket, subscribe, unsubscribe } = useWebSocket();
+  const { connectWebSocket, subscribe, unsubscribe, getUnsubscribedChatRoomId } = useWebSocket();
 
   const applyToggle = useCallback(
     (roomId: number, isUnread: boolean) => {
@@ -60,12 +60,16 @@ const useChatRead = () => {
 
   useEffect(() => {
     void initializeConnection();
-
+    const chatRoomId = getUnsubscribedChatRoomId();
+    if (chatRoomId !== null && chatRoomId !== 0) {
+      console.log('chatRoomId', chatRoomId);
+      applyToggle(chatRoomId, false);
+    }
     return () => {
       unsubscribe(UNREAD_TOPIC);
       unsubscribe(READ_TOPIC);
     };
-  }, [initializeConnection, unsubscribe]);
+  }, [initializeConnection, unsubscribe, getUnsubscribedChatRoomId, applyToggle]);
 };
 
 export default useChatRead;

--- a/src/hooks/useChatRead.ts
+++ b/src/hooks/useChatRead.ts
@@ -11,7 +11,8 @@ const READ_TOPIC = '/user/queue/reads';
 
 const useChatRead = () => {
   const queryClient = useQueryClient();
-  const { connectWebSocket, subscribe, unsubscribe, getUnsubscribedChatRoomId } = useWebSocket();
+  const { connectWebSocket, subscribe, unsubscribe, getUnsubscribedChatRoomId, disconnect } =
+    useWebSocket();
 
   const applyToggle = useCallback(
     (roomId: number, isUnread: boolean) => {
@@ -64,11 +65,18 @@ const useChatRead = () => {
     if (chatRoomId !== null && chatRoomId !== 0) {
       applyToggle(chatRoomId, false);
     }
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        void disconnect();
+      } else {
+        location.reload();
+      }
+    });
     return () => {
       unsubscribe(UNREAD_TOPIC);
       unsubscribe(READ_TOPIC);
     };
-  }, [initializeConnection, unsubscribe, getUnsubscribedChatRoomId, applyToggle]);
+  }, [initializeConnection, unsubscribe, getUnsubscribedChatRoomId, applyToggle, disconnect]);
 };
 
 export default useChatRead;

--- a/src/hooks/useChatRead.ts
+++ b/src/hooks/useChatRead.ts
@@ -65,14 +65,16 @@ const useChatRead = () => {
     if (chatRoomId !== null && chatRoomId !== 0) {
       applyToggle(chatRoomId, false);
     }
-    document.addEventListener('visibilitychange', () => {
+    const handleVisibilityChange = () => {
       if (document.hidden) {
         void disconnect();
       } else {
         location.reload();
       }
-    });
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       unsubscribe(UNREAD_TOPIC);
       unsubscribe(READ_TOPIC);
     };

--- a/src/hooks/useChatRead.ts
+++ b/src/hooks/useChatRead.ts
@@ -62,7 +62,6 @@ const useChatRead = () => {
     void initializeConnection();
     const chatRoomId = getUnsubscribedChatRoomId();
     if (chatRoomId !== null && chatRoomId !== 0) {
-      console.log('chatRoomId', chatRoomId);
       applyToggle(chatRoomId, false);
     }
     return () => {

--- a/src/hooks/useChatRoom.ts
+++ b/src/hooks/useChatRoom.ts
@@ -89,7 +89,7 @@ const useChatRoom = () => {
 
   const [message, setMessage] = useState('');
   const [messages, setMessages] = useState<MessageResponse[]>([]);
-  const { clientRef, connectWebSocket, subscribe, send, unsubscribe } = useWebSocket();
+  const { clientRef, connectWebSocket, subscribe, send, unsubscribe, disconnect } = useWebSocket();
   // 페이지네이션으로 불러온 메시지들을 messages 상태에 동기화
   useEffect(() => {
     if (allMessages.length === 0) {
@@ -111,17 +111,22 @@ const useChatRoom = () => {
         );
       });
     };
-
-    initializeConnection();
-
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) {
+        void disconnect();
+      } else {
+        location.reload();
+      }
+    });
+    void initializeConnection();
     return () => {
       unsubscribe(subscribeTopic(chatRoom.roomId));
     };
-  }, [unsubscribe, chatRoom.roomId, connectWebSocket, subscribe]);
+  }, [unsubscribe, chatRoom.roomId, connectWebSocket, subscribe, disconnect]);
 
   // 메시지 전송
   const sendMessage = useCallback(() => {
-    if (!message.trim() || !clientRef.current || !clientRef.current.connected) return;
+    if (!message.trim()) return;
 
     const messageRequest: MessageRequest = {
       content: message,
@@ -129,7 +134,7 @@ const useChatRoom = () => {
 
     send(publishTopic(chatRoom.roomId), JSON.stringify(messageRequest));
     setMessage('');
-  }, [message, clientRef, send, chatRoom.roomId]);
+  }, [message, send, chatRoom.roomId]);
 
   // 이미지 메시지 전송
   const sendImageMessage = useCallback(

--- a/src/hooks/useChatRoom.ts
+++ b/src/hooks/useChatRoom.ts
@@ -16,11 +16,11 @@ const EMPTY_MESSAGE: MessageResponse = {
 
 const INITIAL_CHAT_ROOM_MESSAGE_SIZE = 20;
 
-const subscribeTopic = (chatRoomId: number) => {
+export const subscribeTopic = (chatRoomId: number) => {
   return `/sub/${chatRoomId}/messages`;
 };
 
-const publishTopic = (chatRoomId: number) => {
+export const publishTopic = (chatRoomId: number) => {
   return `/pub/${chatRoomId}/messages`;
 };
 

--- a/src/hooks/useChatRoom.ts
+++ b/src/hooks/useChatRoom.ts
@@ -111,15 +111,17 @@ const useChatRoom = () => {
         );
       });
     };
-    document.addEventListener('visibilitychange', () => {
+    const handleVisibilityChange = () => {
       if (document.hidden) {
         void disconnect();
       } else {
         location.reload();
       }
-    });
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
     void initializeConnection();
     return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       unsubscribe(subscribeTopic(chatRoom.roomId));
     };
   }, [unsubscribe, chatRoom.roomId, connectWebSocket, subscribe, disconnect]);

--- a/src/pages/Chat/ChatPage.tsx
+++ b/src/pages/Chat/ChatPage.tsx
@@ -4,8 +4,15 @@ import Header from '@/components/common/Header';
 import useChatRoom from '@/hooks/useChatRoom';
 import ChatSendSection from '@/pages/Chat/components/ChatSendSection';
 import ChatMessageSection from '@/pages/Chat/components/ChatMessageSection';
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
+import useNav from '@/hooks/useNav';
+import deleteChatRoom from '@/apis/chat/deleteChatRoom';
+import { useMutation } from '@tanstack/react-query';
+import ConfirmModal from '@/components/modal/ConfirmModal';
+import { showToastErrorMessage } from '@/utils/showToastMessage';
+import { subscribeTopic } from '@/hooks/useChatRoom';
+import { useWebSocket } from '@/context/WebSocketContext';
 
 /**
  * 채팅 페이지
@@ -28,13 +35,32 @@ const ChatPage = () => {
     fetchNextPage,
   } = useChatRoom();
 
+  const { unsubscribe } = useWebSocket();
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false);
+  const { goBack } = useNav();
+  const { mutate: deleteChatRoomMutation } = useMutation({
+    mutationFn: deleteChatRoom,
+    onSuccess: () => {
+      goBack();
+    },
+    onError: () => {
+      showToastErrorMessage('채팅방 나가기에 실패했습니다.');
+    },
+  });
+
+  const handleDeleteChatRoom = () => {
+    deleteChatRoomMutation(chatRoom.roomId);
+    unsubscribe(subscribeTopic(chatRoom.roomId));
+  };
+
   return (
     <Container>
       <Header
-        variant="page"
+        variant="chat"
         title={
           chatRoom.roomName.length > 16 ? `${chatRoom.roomName.slice(0, 16)}...` : chatRoom.roomName
         }
+        onClick={() => setIsConfirmOpen(true)}
       />
       <div className="flex flex-col px-4 py-2 gap-1 h-[calc(100dvh-110px)]">
         <Suspense fallback={<LoadingSpinner />}>
@@ -53,6 +79,13 @@ const ChatPage = () => {
           sendImageMessage={sendImageMessage}
         />
       </div>
+      <ConfirmModal
+        isOpen={isConfirmOpen}
+        onClose={() => setIsConfirmOpen(false)}
+        onConfirm={handleDeleteChatRoom}
+        title="채팅방 나가기"
+        message="채팅방을 나가시겠습니까?"
+      />
       <Footer initialSelected="none" />
     </Container>
   );

--- a/src/pages/FestivalInfo/components/FestivalPoster.tsx
+++ b/src/pages/FestivalInfo/components/FestivalPoster.tsx
@@ -25,7 +25,7 @@ const FestivalPoster = ({
   } = useSlider({ itemCount: allImages.length });
 
   const arrowButtonClasses =
-    'absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden md:flex';
+    'absolute top-1/2 transform -translate-y-1/2 bg-black/30 hover:bg-black/50 text-white w-10 h-10 rounded-full flex items-center justify-center transition-all duration-200 hidden sm:flex';
 
   return (
     <div className="w-full relative">

--- a/src/pages/Festivals/components/FestivalCard.tsx
+++ b/src/pages/Festivals/components/FestivalCard.tsx
@@ -43,7 +43,7 @@ const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
                 filled
                 className={`${data.averageScore !== null ? 'text-yellow-400' : 'text-gray-300'} size-4`}
               />
-              <span className="text-sm sm:text-xs  text-gray-700">{data.averageScore ?? '-'}</span>
+              <span className="text-sm sm:text-xs text-gray-700">{data.averageScore ?? '-'}</span>
             </div>
             <div className="flex items-center gap-1">
               <Heart fill className="size-3" />

--- a/src/pages/Festivals/components/FestivalCard.tsx
+++ b/src/pages/Festivals/components/FestivalCard.tsx
@@ -1,3 +1,5 @@
+import Heart from '@/components/icon/HeartIcon';
+import StarIcon from '@/components/icon/StarIcon';
 import { ROUTE_PATH } from '@/constants/routes';
 import type { Festival } from '@/types/FestivalType';
 import { generatePath, Link } from 'react-router-dom';
@@ -35,6 +37,19 @@ const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
           <p className="text-sm sm:text-xs text-gray-500" title={data.addr1}>
             {data.addr1.split(' ').slice(0, 2).join(' ')}
           </p>
+          <div className="flex items-center gap-2 justify-end font-bold">
+            <div className="flex items-center gap-1">
+              <StarIcon
+                filled
+                className={`${data.averageScore !== null ? 'text-yellow-400' : 'text-gray-300'} size-4`}
+              />
+              <span className="text-sm sm:text-xs  text-gray-700">{data.averageScore ?? '-'}</span>
+            </div>
+            <div className="flex items-center gap-1">
+              <Heart fill className="size-3" />
+              <span className="text-sm sm:text-xs text-gray-700">{data.wishCount}</span>
+            </div>
+          </div>
         </div>
       </div>
     </Link>

--- a/src/pages/My/components/MyPageChatSection.tsx
+++ b/src/pages/My/components/MyPageChatSection.tsx
@@ -9,6 +9,7 @@ import useChatRead from '@/hooks/useChatRead';
 
 const MyPageChatSection = () => {
   useChatRead();
+
   const { data, isFetching, hasNextPage, fetchNextPage } = useSuspenseInfiniteQuery({
     queryKey: ['myChats'],
     queryFn: ({ pageParam = 0 }) => getMyChats(pageParam, 5),


### PR DESCRIPTION
### WebSocket 재연결 시 구독 자동 복구 개선
- onConnect에서 모든 활성 구독을 자동 재구독하도록 개선
- 기존 refCount > 0 && !entry.subscription 조건 제거, 모든 활성 구독 재구독
- 연결이 끊긴 뒤 재연결 시 기존 구독 자동 복구
- 다른 탭에서 다시 돌아왔을 때 자동 새로고침 추가
관련 이슈: close #80 

### 채팅방 나가기
- 채팅 페이지에서 헤더 나가기 버튼(기능) 추가

### 채팅페이지에서 마이페이지 이동 시 읽지 않음 표시 문제
- 나간 채팅방 id를 기억해서 읽지 않음을 따로 처리해주는 방식으로 해결
관련 이슈: close #78 

### 축제 목록 페이지
- 별점 추가
- 좋아요 수 추가

### 축제 상세 페이지 이미지 슬라이더 반응형 변경
- 기존 md 크기에서 sm 크기로 변경하여 모바일과 데스크탑의 구분이 더 확실하게 변경
관련 이슈: close #77 
