### PR TITLE
축제 진행중 필터 적용 및 AI 추천 캐시 적용

### DIFF
--- a/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
   href="/festival/143"
 >
   <div
-    class="aspect-[3/2] w-full"
+    class="aspect-[3/2] w-full relative brightness-40"
   >
     <img
       alt="안동국제탈춤페스티벌 축제 이미지"
@@ -102,7 +102,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
   href="/festival/2583"
 >
   <div
-    class="aspect-[3/2] w-full"
+    class="aspect-[3/2] w-full relative brightness-40"
   >
     <img
       alt="한옥마을전통연희 퍼레이드-노상놀이야 축제 이미지"
@@ -195,7 +195,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천이 없을 때
   href="/festival/2583"
 >
   <div
-    class="aspect-[3/2] w-full"
+    class="aspect-[3/2] w-full relative brightness-40"
   >
     <img
       alt="한옥마을전통연희 퍼레이드-노상놀이야 축제 이미지"

--- a/src/apis/festivals/getFestivals.ts
+++ b/src/apis/festivals/getFestivals.ts
@@ -6,18 +6,24 @@ import type { ApiErrorResponse } from '@/apis/apiInstance';
 import type { AxiosResponse } from 'axios';
 import { generatePath } from 'react-router-dom';
 
+const DEFAULT_SIZE = 6;
+const DEFAULT_PAGE = 0;
+const DEFAULT_CURRENT = true;
+
 export const getFestivals = async ({
   areaId,
-  size = 6,
-  page = 0,
+  size = DEFAULT_SIZE,
+  page = DEFAULT_PAGE,
+  current = DEFAULT_CURRENT,
 }: {
   areaId: string;
   size?: number;
   page?: number;
+  current?: boolean;
 }): Promise<AxiosResponse<ApiResponseList<Festival>, ApiErrorResponse>> => {
   return await apiInstance.get<ApiResponseList<Festival>>(
     generatePath(API_ENDPOINTS.FESTIVALS, { areaId }),
-    { params: { size, page } },
+    { params: { size, page, current } },
   );
 };
 

--- a/src/pages/Festivals/components/FestivalCard.tsx
+++ b/src/pages/Festivals/components/FestivalCard.tsx
@@ -9,19 +9,34 @@ interface FestivalCardProps {
   highlight?: boolean;
 }
 
+const isInProgress = (endDateData: string): boolean => {
+  const endDate = new Date(endDateData);
+  const today = new Date();
+  const diffTime = endDate.getTime() - today.getTime();
+  return diffTime >= 0;
+};
+
 const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
+  const isInProgressFestival = isInProgress(data.endDate);
   return (
     <Link
       className={`bg-white rounded-xl overflow-hidden shadow-lg hover:shadow-xl transition-all duration-100 hover:scale-[1.02] cursor-pointer ${highlight ? 'ring-3 ring-primary-300' : ''}`}
       to={generatePath(ROUTE_PATH.FESTIVAL_INFO, { festivalId: data.id.toString() })}
     >
       {/* 이미지 섹션 */}
-      <div className="aspect-[3/2] w-full">
+      <div
+        className={`aspect-[3/2] w-full relative ${!isInProgressFestival ? 'brightness-40' : ''}`}
+      >
         <img
           src={data.posterInfo}
           alt={`${data.title} 축제 이미지`}
           className="w-full h-full object-cover"
         />
+        {isInProgressFestival && (
+          <div className="absolute top-0 right-0 p-2 bg-primary-400 rounded-bl-xl">
+            <span className="text-white text-sm font-bold">진행 중</span>
+          </div>
+        )}
       </div>
 
       {/* 콘텐츠 섹션 */}

--- a/src/pages/Festivals/components/FestivalCard.tsx
+++ b/src/pages/Festivals/components/FestivalCard.tsx
@@ -43,7 +43,9 @@ const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
                 filled
                 className={`${data.averageScore !== null ? 'text-yellow-400' : 'text-gray-300'} size-4`}
               />
-              <span className="text-sm sm:text-xs text-gray-700">{data.averageScore ?? '-'}</span>
+              <span className="text-sm sm:text-xs text-gray-700">
+                {data.averageScore?.toFixed(1) ?? '-'}
+              </span>
             </div>
             <div className="flex items-center gap-1">
               <Heart fill className="size-3" />

--- a/src/pages/Festivals/components/FestivalsAISection.tsx
+++ b/src/pages/Festivals/components/FestivalsAISection.tsx
@@ -1,12 +1,16 @@
 import FestivalsSection from '@/pages/Festivals/components/FestivalsSection';
-import { useMutation } from '@tanstack/react-query';
-import { useLocation, useNavigate } from 'react-router-dom';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import postFestivalsPick, { type PostFestivalsPickBody } from '@/apis/festivals/postFestivalsPick';
 import { useEffect } from 'react';
+import type { ApiResponseList } from '@/apis/apiResponse';
+import type { Festival } from '@/types/FestivalType';
+import type { AxiosResponse } from 'axios';
 
 const FestivalsAISection = () => {
   const location = useLocation();
   const navigate = useNavigate();
+  const { areaId } = useParams();
 
   // Pick 페이지에서 전달된 요청 데이터
   const requestData = location.state?.requestData as PostFestivalsPickBody;
@@ -28,7 +32,9 @@ const FestivalsAISection = () => {
     }
   }, [requestData, location.pathname, location.search, location.state, navigate]);
 
-  // API 호출을 위한 mutation
+  const queryClient = useQueryClient();
+
+  // API 호출을 위한 mutation (성공 시 캐시에 저장)
   const {
     mutate: mutateFestivalPick,
     isPending,
@@ -38,19 +44,35 @@ const FestivalsAISection = () => {
     onError: (error) => {
       console.error(error);
     },
+    onSuccess: (data, variables) => {
+      const cacheKey = ['aiPick', variables.areaCode];
+      queryClient.setQueryData(cacheKey, data);
+    },
   });
 
-  // requestData가 있으면 API 호출
+  // requestData가 있으면 요청을 우선 수행
   useEffect(() => {
     if (requestData && !isPending) {
       mutateFestivalPick(requestData);
     }
-  }, [requestData, isPending, mutateFestivalPick]);
+  }, [requestData, isPending, mutateFestivalPick, queryClient]);
 
-  // mutation 성공 데이터가 있으면 사용
-  if (festivalData) {
-    const title = '맞춤 AI Pick 축제';
-    const festivalsData = (festivalData.data?.content || []).slice(0, 2);
+  // requestData가 있으면 해당 응답만 사용,
+  const title = '맞춤 AI Pick 축제';
+  if (requestData) {
+    if (festivalData) {
+      const festivalsData = (festivalData.data.content || []).slice(0, 2);
+      return <FestivalsSection title={title} data={festivalsData} highlight />;
+    }
+    return null;
+  }
+  // 캐시가 있으면 areaId와 동일한 최근 캐시 사용
+  const cachedEntries = queryClient.getQueriesData<AxiosResponse<ApiResponseList<Festival>>>({
+    queryKey: ['aiPick', Number(areaId)],
+  });
+  const cachedLatest = cachedEntries.at(-1)?.[1];
+  if (cachedLatest) {
+    const festivalsData = (cachedLatest.data.content || []).slice(0, 2);
     return <FestivalsSection title={title} data={festivalsData} highlight />;
   }
 

--- a/src/pages/Festivals/components/FestivalsAreaSection.tsx
+++ b/src/pages/Festivals/components/FestivalsAreaSection.tsx
@@ -1,19 +1,35 @@
 import { useSuspenseInfiniteQuery } from '@tanstack/react-query';
 import getFestivals from '@/apis/festivals/getFestivals';
 import FestivalsSection from '@/pages/Festivals/components/FestivalsSection';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import useIntersectionObserver from '@/hooks/useIntersectionObserver';
 import LoadingSpinner from '@/components/loading/LoadingSpinner';
-import EmptyComponent from '@/components/common/EmptyComponent';
 import MAP_PINS from '@/constants/mapPins';
 
 const FestivalsAreaSection = () => {
   const { areaId } = useParams();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const showCurrent = (searchParams.get('current') ?? 'true') === 'true';
+  const handleCurrentFilter = () => {
+    setSearchParams(
+      (prev) => {
+        const current = (prev.get('current') ?? 'true') === 'true' ? 'false' : 'true';
+        prev.set('current', current);
+        return prev;
+      },
+      { replace: true },
+    );
+  };
 
   const { data, isFetching, hasNextPage, fetchNextPage } = useSuspenseInfiniteQuery({
-    queryKey: ['festivals', areaId],
+    queryKey: ['festivals', areaId, showCurrent],
     queryFn: ({ pageParam = 0 }) =>
-      getFestivals({ areaId: areaId || '', size: 6, page: pageParam }),
+      getFestivals({
+        areaId: areaId || '',
+        size: 6,
+        page: pageParam,
+        current: showCurrent,
+      }),
     getNextPageParam: (lastPage, allPages) => {
       return lastPage.data.last ? undefined : allPages.length;
     },
@@ -30,20 +46,28 @@ const FestivalsAreaSection = () => {
   const area = MAP_PINS.find((pin) => pin.areaId === areaId);
   const areaName = area?.name ?? '지역';
 
-  if (festivals.length === 0) {
-    return (
-      <div className="w-full h-full flex flex-col items-center justify-center">
-        <img src="/lost404.svg" alt="no festivals" className="w-64 h-64 mt-12 drop-shadow-lg" />
-        <EmptyComponent
-          title="해당 지역의 축제가 없습니다."
-          description="다른 지역의 축제를 찾아보세요!"
-        />
-      </div>
-    );
-  }
   return (
-    <div>
-      <FestivalsSection title={`${areaName}의 축제`} data={festivals} />
+    <div className="w-full h-full">
+      <FestivalsSection
+        title={`${areaName}의 축제`}
+        data={festivals}
+        rightAction={
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-800">진행 중</span>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={showCurrent}
+              onClick={handleCurrentFilter}
+              className={`relative inline-flex h-7 w-11 items-center rounded-2xl transition-colors ${showCurrent ? 'bg-primary-300' : 'bg-gray-200'}`}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow transition-transform duration-200 ease-out ${showCurrent ? 'translate-x-5' : 'translate-x-1'}`}
+              />
+            </button>
+          </div>
+        }
+      />
       {hasNextPage && <div ref={observerRef} className="h-1" />}
       {isFetching && <LoadingSpinner className="mt-8" />}
     </div>

--- a/src/pages/Festivals/components/FestivalsSection.tsx
+++ b/src/pages/Festivals/components/FestivalsSection.tsx
@@ -1,21 +1,42 @@
+import EmptyComponent from '@/components/common/EmptyComponent';
 import FestivalCard from '@/pages/Festivals/components/FestivalCard';
 import type { Festival } from '@/types/FestivalType';
+import type { ReactNode } from 'react';
 
 interface FestivalsSectionProps {
   title: string;
   data: Festival[];
   highlight?: boolean;
+  rightAction?: ReactNode;
 }
 
-const FestivalsSection = ({ title, data, highlight = false }: FestivalsSectionProps) => {
+const FestivalsSection = ({
+  title,
+  data,
+  highlight = false,
+  rightAction,
+}: FestivalsSectionProps) => {
   return (
     <section className="w-full">
-      <h2 className="text-2xl font-bold mb-6 text-left text-gray-900">{title}</h2>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
-        {data?.map((festival) => (
-          <FestivalCard key={festival.id} data={festival} highlight={highlight} />
-        ))}
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold text-left text-gray-900">{title}</h2>
+        {rightAction}
       </div>
+      {data.length === 0 ? (
+        <div className="w-full h-full flex flex-col items-center justify-center">
+          <img src="/lost404.svg" alt="no festivals" className="w-64 h-64 mt-12 drop-shadow-lg" />
+          <EmptyComponent
+            title="진행 중인 축제가 없습니다."
+            description="진행 중 체크를 해제하거나 다른 지역의 축제를 찾아보세요!"
+          />
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 ">
+          {data.map((festival) => (
+            <FestivalCard key={festival.id} data={festival} highlight={highlight} />
+          ))}
+        </div>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
### 축제 목록 페이지
- AI 추천을 받고 축제 상세 페이지를 간 다음 뒤로가기를 했을 때 AI 추천 내용이 남도록 변경했습니다
- 리뷰를 소수점 첫째자리까지 제한하였습니다.
- 축제를 진행 중인 축제와 종료한 축제를 토글로 전환하여 볼 수 있도록 했습니다