### PR TITLE
Fix/validate text size

### DIFF
--- a/src/__tests__/pages/__snapshots__/ChatPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/ChatPage.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`ChatPage > 스냅샷 - 전송 컴포넌트 > chat-send-section 1`] = `
   >
     <textarea
       class="w-full py-2 bg-transparent text-sm outline-none placeholder:text-gray-400 resize-none overflow-hidden whitespace-pre-wrap leading-5"
+      maxlength="255"
       placeholder="메시지 입력..."
       rows="1"
       style="height: 0px;"

--- a/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalInfoPage.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`리뷰 섹션 컴포넌트 > 기본 렌더링 > 리뷰 섹션 스냅샷
 
 exports[`리뷰 섹션 컴포넌트 > 기본 렌더링 > 첫 번째 리뷰 카드 구성 요소별 스냅샷 > first-review-content 1`] = `
 <p
-  class="text-sm text-gray-700"
+  class="text-sm text-gray-700 break-all"
 >
   꽃이 예뻐요.
 </p>
@@ -77,7 +77,7 @@ exports[`리뷰 섹션 컴포넌트 > 기본 렌더링 > 첫 번째 리뷰 카�
 
 exports[`리뷰 섹션 컴포넌트 > 기본 렌더링 > 첫 번째 리뷰 카드 구성 요소별 스냅샷 > first-review-reviewer-name 1`] = `
 <p
-  class="font-medium text-gray-900"
+  class="font-medium text-gray-900 break-all"
 >
   홍길동
 </p>

--- a/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/FestivalsPage.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
     class="p-4"
   >
     <h3
-      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem]"
+      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem] break-all"
     >
       안동국제탈춤페스티벌
     </h3>
@@ -34,7 +34,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
         2025-10-05
       </p>
       <p
-        class="text-sm sm:text-xs text-gray-500"
+        class="text-sm sm:text-xs text-gray-500 break-all"
         title="경상북도 안동시 육사로 239 (운흥동)"
       >
         경상북도 안동시
@@ -114,7 +114,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
     class="p-4"
   >
     <h3
-      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem]"
+      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem] break-all"
     >
       한옥마을전통연희 퍼레이드-노상놀이야
     </h3>
@@ -129,7 +129,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천 섹션과 일
         2025-10-25
       </p>
       <p
-        class="text-sm sm:text-xs text-gray-500"
+        class="text-sm sm:text-xs text-gray-500 break-all"
         title="전북특별자치도 전주시 완산구 태조로 44 (풍남동3가)"
       >
         전북특별자치도 전주시
@@ -207,7 +207,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천이 없을 때
     class="p-4"
   >
     <h3
-      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem]"
+      class="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem] break-all"
     >
       한옥마을전통연희 퍼레이드-노상놀이야
     </h3>
@@ -222,7 +222,7 @@ exports[`FestivalsPage 테스트 > 스냅샷 테스트 > AI 추천이 없을 때
         2025-10-25
       </p>
       <p
-        class="text-sm sm:text-xs text-gray-500"
+        class="text-sm sm:text-xs text-gray-500 break-all"
         title="전북특별자치도 전주시 완산구 태조로 44 (풍남동3가)"
       >
         전북특별자치도 전주시

--- a/src/__tests__/pages/__snapshots__/PickPage.test.tsx.snap
+++ b/src/__tests__/pages/__snapshots__/PickPage.test.tsx.snap
@@ -359,23 +359,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3�
 </div>
 `;
 
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-3-먹거리-selected 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="먹거리"
-    class="size-[100px] rounded-lg border-3 border-primary-300 object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/food.svg"
-  />
-  <p
-    class="text-lg font-bold"
-  >
-    먹거리
-  </p>
-</div>
-`;
-
 exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-3-휴식-selected 1`] = `
 <div
   class="w-full h-full flex flex-col items-center justify-center gap-3"
@@ -444,23 +427,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3�
 </div>
 `;
 
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-6-트렌디-unselected 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="트렌디"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/trendy.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    트렌디
-  </p>
-</div>
-`;
-
 exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-7-사진촬영-unselected 1`] = `
 <div
   class="w-full h-full flex flex-col items-center justify-center gap-3"
@@ -478,23 +444,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3�
 </div>
 `;
 
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-7-커뮤니티-unselected 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="커뮤니티"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/community.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    커뮤니티
-  </p>
-</div>
-`;
-
 exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-8-지역특색-unselected 1`] = `
 <div
   class="w-full h-full flex flex-col items-center justify-center gap-3"
@@ -508,23 +457,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3�
     class="text-lg "
   >
     지역특색
-  </p>
-</div>
-`;
-
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 3개 선택 후 상태 스냅샷 > style-card-9-국제-unselected 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="국제"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/international.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    국제
   </p>
 </div>
 `;
@@ -586,23 +518,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - �
     class="text-lg "
   >
     예술/공연
-  </p>
-</div>
-`;
-
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-3-먹거리-initial 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="먹거리"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/food.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    먹거리
   </p>
 </div>
 `;
@@ -675,23 +590,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - �
 </div>
 `;
 
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-6-트렌디-initial 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="트렌디"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/trendy.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    트렌디
-  </p>
-</div>
-`;
-
 exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-7-사진촬영-initial 1`] = `
 <div
   class="w-full h-full flex flex-col items-center justify-center gap-3"
@@ -709,23 +607,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - �
 </div>
 `;
 
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-7-커뮤니티-initial 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="커뮤니티"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/community.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    커뮤니티
-  </p>
-</div>
-`;
-
 exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-8-지역특색-initial 1`] = `
 <div
   class="w-full h-full flex flex-col items-center justify-center gap-3"
@@ -739,23 +620,6 @@ exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - �
     class="text-lg "
   >
     지역특색
-  </p>
-</div>
-`;
-
-exports[`PickPage 테스트 > 스냅샷 테스트 > 스타일 선택 화면 - 초기 상태 스냅샷 > style-card-9-국제-initial 1`] = `
-<div
-  class="w-full h-full flex flex-col items-center justify-center gap-3"
->
-  <img
-    alt="국제"
-    class="size-[100px] rounded-lg  object-cover bg-transparent border-2 border-gray-900"
-    src="/pickStyle/international.svg"
-  />
-  <p
-    class="text-lg "
-  >
-    국제
   </p>
 </div>
 `;

--- a/src/components/festivalForm/FestivalFormAddressCard.tsx
+++ b/src/components/festivalForm/FestivalFormAddressCard.tsx
@@ -1,8 +1,11 @@
 import BorderCardComponent from '@/components/common/BorderCardComponent';
 import type { FestivalCardProps } from '@/types/FestivalFormTypes';
+import TextInputWithCounter from '../form/TextInputWithCounter';
 
 /**
  * 축제 등록,수정 폼 주소 카드
+ * 주소는 최대 255자까지 입력 가능합니다.
+ * 상세 주소는 최대 255자까지 입력 가능합니다.
  * @param formData - 폼 데이터
  * @param handleInputChange - 입력 변경 핸들러
  * @param isSubmitting - 제출 중 여부
@@ -20,24 +23,22 @@ const FestivalFormAddressCard = ({
         <label htmlFor="addr1" className="font-semibold">
           주소 <span className="text-red-500">*</span>
         </label>
-        <input
-          id="addr1"
-          name="addr1"
-          type="text"
+        <TextInputWithCounter
           value={formData.addr1}
           onChange={handleInputChange}
           placeholder="기본 주소를 입력하세요"
-          className="border border-gray-200 rounded-lg p-3"
+          maxLength={255}
+          type="input"
+          name="addr1"
           disabled={isSubmitting}
         />
-        <input
-          id="addr2"
-          name="addr2"
-          type="text"
+        <TextInputWithCounter
           value={formData.addr2}
           onChange={handleInputChange}
           placeholder="상세 주소를 입력하세요 (선택)"
-          className="border border-gray-200 rounded-lg p-3"
+          maxLength={255}
+          type="input"
+          name="addr2"
           disabled={isSubmitting}
         />
       </div>

--- a/src/components/festivalForm/FestivalFormHomePageCard.tsx
+++ b/src/components/festivalForm/FestivalFormHomePageCard.tsx
@@ -1,8 +1,10 @@
 import BorderCardComponent from '@/components/common/BorderCardComponent';
 import type { FestivalCardProps } from '@/types/FestivalFormTypes';
+import TextInputWithCounter from '../form/TextInputWithCounter';
 
 /**
  * 축제 등록,수정 폼 홈페이지 카드
+ * 홈페이지 URL은 최대 500자까지 입력 가능합니다.
  * @param formData - 폼 데이터
  * @param handleInputChange - 입력 변경 핸들러
  * @param isSubmitting - 제출 중 여부
@@ -20,14 +22,13 @@ const FestivalFormHomePageCard = ({
         <label htmlFor="homePage" className="font-semibold">
           홈페이지 URL
         </label>
-        <input
-          id="homePage"
-          name="homePage"
-          type="url"
+        <TextInputWithCounter
           value={formData.homePage}
           onChange={handleInputChange}
           placeholder="https://example.com"
-          className="border border-gray-200 rounded-lg p-3"
+          maxLength={500}
+          type="input"
+          name="homePage"
           disabled={isSubmitting}
         />
       </div>

--- a/src/components/festivalForm/FestivalFormNameCard.tsx
+++ b/src/components/festivalForm/FestivalFormNameCard.tsx
@@ -1,8 +1,10 @@
 import BorderCardComponent from '@/components/common/BorderCardComponent';
 import type { FestivalCardProps } from '@/types/FestivalFormTypes';
+import TextInputWithCounter from '../form/TextInputWithCounter';
 
 /**
  * 축제 등록,수정 폼 제목 카드
+ * 축제 제목은 최대 255자까지 입력 가능합니다.
  * @param formData - 폼 데이터
  * @param handleInputChange - 입력 변경 핸들러
  * @param isSubmitting - 제출 중 여부
@@ -16,14 +18,13 @@ const FestivalFormNameCard = ({ formData, handleInputChange, isSubmitting }: Fes
         <label htmlFor="title" className="font-semibold">
           축제 제목 <span className="text-red-500">*</span>
         </label>
-        <input
-          id="title"
-          name="title"
-          type="text"
+        <TextInputWithCounter
           value={formData.title}
           onChange={handleInputChange}
           placeholder="축제 제목을 입력하세요"
-          className="border border-gray-200 rounded-lg p-3"
+          maxLength={255}
+          type="input"
+          name="title"
           disabled={isSubmitting}
         />
       </div>

--- a/src/components/festivalForm/FestivalFormOverviewCard.tsx
+++ b/src/components/festivalForm/FestivalFormOverviewCard.tsx
@@ -3,6 +3,9 @@ import type { FestivalCardProps } from '@/types/FestivalFormTypes';
 import TextInputWithCounter from '@/components/form/TextInputWithCounter';
 /**
  * 축제 등록,수정 폼 개요 카드
+ * 축제 개요는 최소 30자 이상 입력 가능합니다.
+ * 축제 개요는 최대 5000자까지 입력 가능합니다.
+ * 축제 개요는 textarea로 입력 가능합니다.
  * @param formData - 폼 데이터
  * @param handleInputChange - 입력 변경 핸들러
  * @param isSubmitting - 제출 중 여부

--- a/src/constants/systemMessages.ts
+++ b/src/constants/systemMessages.ts
@@ -162,4 +162,8 @@ export const SYSTEM_MESSAGES = {
     PARSING_ERROR: '데이터를 처리하는 중 오류가 발생했습니다.',
     URL_INVALID: '유효하지 않은 URL입니다.',
   },
+  // 채팅 관련
+  CHAT: {
+    MAX_MESSAGE_LENGTH: '최대 255자까지 입력 가능합니다.',
+  },
 } as const;

--- a/src/hooks/useChatRoom.ts
+++ b/src/hooks/useChatRoom.ts
@@ -4,6 +4,8 @@ import { useParams } from 'react-router-dom';
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import getChatRoomMessage from '@/apis/chat/getChatRoomMessage';
 import { useWebSocket } from '@/context/WebSocketContext';
+import { showToastErrorMessage } from '@/utils/showToastMessage';
+import { SYSTEM_MESSAGES } from '@/constants/systemMessages';
 
 const EMPTY_MESSAGE: MessageResponse = {
   id: 0,
@@ -129,6 +131,10 @@ const useChatRoom = () => {
   // 메시지 전송
   const sendMessage = useCallback(() => {
     if (!message.trim()) return;
+    if (message.length > MAX_MESSAGE_LENGTH) {
+      showToastErrorMessage(SYSTEM_MESSAGES.CHAT.MAX_MESSAGE_LENGTH);
+      return;
+    }
 
     const messageRequest: MessageRequest = {
       content: message,
@@ -152,10 +158,22 @@ const useChatRoom = () => {
     },
     [clientRef, send, chatRoom.roomId],
   );
+  // 채팅 글자수를 255자로 제한
+  const MAX_MESSAGE_LENGTH = 255;
 
   // 메세지 변경 이벤트 핸들러
+  /**
+   * 255자 이상 입력시 상태가 변하지 않게 하여서 그 이상의 입력을 제한하였습니다.
+   * 또한 혹시 모를 에러를 대비해서 만약에 토스트 메시지를 표시하는 것을 추가하였습니다.(그치만 입력 자체를 안받기 때문에 무관할 것 같습니다.)
+   * 또한 textarea의 maxLength 속성을 사용하여서 그 이상의 입력을 제한하였습니다.
+   * @param e - 메시지 변경 이벤트
+   * @returns void
+   */
   const handleMessageChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setMessage(e.target.value);
+    const value = e.target.value;
+    if (value.length <= MAX_MESSAGE_LENGTH) {
+      setMessage(value);
+    }
   }, []);
 
   // 키 누르기 이벤트 핸들러

--- a/src/hooks/useFestivalForm.ts
+++ b/src/hooks/useFestivalForm.ts
@@ -31,7 +31,7 @@ export interface UseFestivalFormReturn {
 
 const defaultForm: FestivalFormData = {
   title: '',
-  areaCode: '1',  // 축제 등록시 default로 나오는 값이 서울이기 때문에 해당 지역으로 매핑하였습니다.
+  areaCode: '1', // 축제 등록시 default로 나오는 값이 서울이기 때문에 해당 지역으로 매핑하였습니다.
   addr1: '',
   addr2: '',
   startDate: '',

--- a/src/hooks/useFestivalForm.ts
+++ b/src/hooks/useFestivalForm.ts
@@ -31,7 +31,7 @@ export interface UseFestivalFormReturn {
 
 const defaultForm: FestivalFormData = {
   title: '',
-  areaCode: '0',
+  areaCode: '1',  // 축제 등록시 default로 나오는 값이 서울이기 때문에 해당 지역으로 매핑하였습니다.
   addr1: '',
   addr2: '',
   startDate: '',

--- a/src/pages/Chat/components/ChatSendSection.tsx
+++ b/src/pages/Chat/components/ChatSendSection.tsx
@@ -57,6 +57,7 @@ const ChatSendSection = ({
             }}
             placeholder="메시지 입력..."
             rows={1}
+            maxLength={255}
             className="w-full py-2 bg-transparent text-sm outline-none placeholder:text-gray-400 resize-none overflow-hidden whitespace-pre-wrap leading-5"
           />
         ) : (

--- a/src/pages/FestivalInfo/components/FestivalContentAddress.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentAddress.tsx
@@ -1,11 +1,17 @@
 const FestivalContentAddress = ({ address1, address2 }: { address1: string; address2: string }) => {
   return (
     <div className="w-full h-full flex flex-col">
-      <div className="flex items-center gap-2">
-        <img src="/location.svg" alt="location" className="size-4" />
-        <p className="text-sm text-gray-900">{address1}</p>
+      <div className="flex items-start gap-2">
+        <img src="/location.svg" alt="location" className="size-4 shrink-0" />
+        <p className="text-sm text-gray-900 break-all whitespace-pre-wrap min-w-0">
+          {address1}
+        </p>
       </div>
-      {address2 && <span className="text-sm text-gray-900 ml-6">{address2}</span>}
+      {address2 && (
+        <span className="block text-sm text-gray-900 ml-6 break-all whitespace-pre-wrap min-w-0">
+          {address2}
+        </span>
+      )}
     </div>
   );
 };

--- a/src/pages/FestivalInfo/components/FestivalContentAddress.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentAddress.tsx
@@ -3,9 +3,7 @@ const FestivalContentAddress = ({ address1, address2 }: { address1: string; addr
     <div className="w-full h-full flex flex-col">
       <div className="flex items-start gap-2">
         <img src="/location.svg" alt="location" className="size-4 shrink-0" />
-        <p className="text-sm text-gray-900 break-all whitespace-pre-wrap min-w-0">
-          {address1}
-        </p>
+        <p className="text-sm text-gray-900 break-all whitespace-pre-wrap min-w-0">{address1}</p>
       </div>
       {address2 && (
         <span className="block text-sm text-gray-900 ml-6 break-all whitespace-pre-wrap min-w-0">

--- a/src/pages/FestivalInfo/components/FestivalContentNoticeSectionCard.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentNoticeSectionCard.tsx
@@ -14,7 +14,7 @@ const FestivalContentNoticeSectionCard = ({
       onClick={() => onClick?.(notice.id)}
       className="w-full h-full p-3 border border-gray-200 rounded-lg flex items-center bg-white shadow-sm hover:bg-gray-50 hover:border-primary-300 transition-all duration-200 cursor-pointer"
     >
-      <p className="font-medium text-gray-900 text-lg line-clamp-2 w-full text-center">
+      <p className="font-medium text-gray-900 text-lg line-clamp-2 w-full text-center break-all">
         {notice.title}
       </p>
     </button>

--- a/src/pages/FestivalInfo/components/FestivalContentOverviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentOverviewSection.tsx
@@ -62,7 +62,9 @@ const FestivalContentOverviewSection = ({
           </div>
         )}
       </div>
-      <p className="text-sm text-gray-900 leading-relaxed whitespace-pre-wrap">{displayText}</p>
+      <p className="text-sm text-gray-900 leading-relaxed whitespace-pre-wrap break-words">
+        {displayText}
+      </p>
       {shouldShowButton && (
         <div className="flex justify-center">
           <Button variant="tertiary" size="sm" fullWidth onClick={() => setIsExpanded(!isExpanded)}>

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -63,7 +63,7 @@ const FestivalContentReviewSection = ({
           className="p-3 border border-gray-200 rounded-lg flex flex-col gap-2"
         >
           <div className="flex items-center justify-between">
-            <p className="font-medium text-gray-900">{review.reviewerName}</p>
+            <p className="font-medium text-gray-900 break-all">{review.reviewerName}</p>
             <div className="flex items-center gap-2">
               <StarRating rating={review.score} />
               {isMyReview(review) && (
@@ -80,7 +80,7 @@ const FestivalContentReviewSection = ({
           </div>
 
           <FestivalContentReviewMediaSlider review={review} festivalTitle={festivalTitle} />
-          <p className="text-sm text-gray-700">{review.content}</p>
+          <p className="text-sm text-gray-700 break-all">{review.content}</p>
         </div>
       ))}
 

--- a/src/pages/FestivalInfo/components/FestivalContentTitle.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentTitle.tsx
@@ -1,5 +1,5 @@
 const FestivalContentTitle = ({ title }: { title: string }) => {
-  return <h1 className="text-xl font-bold">{title}</h1>;
+  return <h1 className="text-xl font-bold break-words">{title}</h1>;
 };
 
 export default FestivalContentTitle;

--- a/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
+++ b/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
@@ -52,9 +52,7 @@ export const FestivalInfoNoticeCard = ({
             {new Date(notice.updatedDate).toLocaleDateString()}
           </span>
         </div>
-        <p className="text-gray-700 mb-3 break-all whitespace-pre-wrap min-w-0">
-          {notice.content}
-        </p>
+        <p className="text-gray-700 mb-3 break-all whitespace-pre-wrap min-w-0">{notice.content}</p>
         {notice.images && notice.images.length > 0 && (
           <div className="mt-3 flex gap-2 flex-wrap">
             {notice.images.map((image, index) => (

--- a/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
+++ b/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
@@ -24,9 +24,9 @@ export const FestivalInfoNoticeCard = ({
   handleDeleteNotice,
   isDeleting,
 }: FestivalInfoNoticeCardProps) => {
-  if (!notice) return null;
   const [isImageModalOpen, setIsImageModalOpen] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  if (!notice) return null;
   const mediaItems: MediaItem[] = notice.images.map((image) => ({ type: 'image', url: image }));
 
   const handleImageClick = (index: number) => {

--- a/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
+++ b/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
@@ -47,12 +47,14 @@ export const FestivalInfoNoticeCard = ({
       >
         <div className="flex justify-between items-start mb-2">
           <PickIcon name={PICK_ICONS.NOTICE} size={20} className="mt-1 mr-2" />
-          <h3 className="font-semibold text-lg text-gray-900 flex-1">{notice.title}</h3>
+          <h3 className="font-semibold text-lg text-gray-900 flex-1 break-all">{notice.title}</h3>
           <span className="text-sm text-gray-500 ml-2">
             {new Date(notice.updatedDate).toLocaleDateString()}
           </span>
         </div>
-        <p className="text-gray-700 mb-3">{notice.content}</p>
+        <p className="text-gray-700 mb-3 break-all whitespace-pre-wrap min-w-0">
+          {notice.content}
+        </p>
         {notice.images && notice.images.length > 0 && (
           <div className="mt-3 flex gap-2 flex-wrap">
             {notice.images.map((image, index) => (

--- a/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
+++ b/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeCard.tsx
@@ -2,6 +2,8 @@ import PickIcon from '@/components/common/PickIcon';
 import { PICK_ICONS } from '@/constants/pickIcons';
 import FormSubmitButtons from '@/components/common/FormSubmitButtons';
 import type { Notice } from '@/types/Notice';
+import { useState } from 'react';
+import ImageModal, { type MediaItem } from '@/components/modal/ImageModal';
 
 interface FestivalInfoNoticeCardProps {
   notice: Notice;
@@ -23,51 +25,72 @@ export const FestivalInfoNoticeCard = ({
   isDeleting,
 }: FestivalInfoNoticeCardProps) => {
   if (!notice) return null;
-  return (
-    <div
-      key={notice.id}
-      ref={(el) => {
-        noticeRefs.current[notice.id] = el;
-      }}
-      className={`p-4 border border-gray-200 rounded-lg bg-white shadow-sm transition-all duration-300 ${
-        focusNoticeId === notice.id ? 'ring-2 ring-primary-300 ring-opacity-50' : ''
-      }`}
-    >
-      <div className="flex justify-between items-start mb-2">
-        <PickIcon name={PICK_ICONS.NOTICE} size={20} className="mt-1 mr-2" />
-        <h3 className="font-semibold text-lg text-gray-900 flex-1">{notice.title}</h3>
-        <span className="text-sm text-gray-500 ml-2">
-          {new Date(notice.updatedDate).toLocaleDateString()}
-        </span>
-      </div>
-      <p className="text-gray-700 mb-3">{notice.content}</p>
-      {notice.images && notice.images.length > 0 && (
-        <div className="mt-3 flex gap-2 flex-wrap">
-          {notice.images.map((image, index) => (
-            <img
-              key={index}
-              src={image}
-              alt={`공지사항 이미지 ${index + 1}`}
-              className="w-20 h-20 object-cover rounded border border-gray-200 hover:scale-105 transition-transform duration-200"
-            />
-          ))}
-        </div>
-      )}
+  const [isImageModalOpen, setIsImageModalOpen] = useState(false);
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+  const mediaItems: MediaItem[] = notice.images.map((image) => ({ type: 'image', url: image }));
 
-      {isCurrentUserManager && (
-        <div className="mt-4 pt-3 border-t border-gray-100">
-          <FormSubmitButtons
-            onCancel={() => handleEditNotice(notice.id)}
-            onSubmit={() => handleDeleteNotice(notice.id)}
-            isEdit={false}
-            isDisabled={isDeleting}
-            isLoading={isDeleting}
-            submitLabel="삭제"
-            cancelLabel="수정"
-            submitType="button"
-          />
+  const handleImageClick = (index: number) => {
+    setSelectedImageIndex(index);
+    setIsImageModalOpen(true);
+  };
+
+  return (
+    <>
+      <div
+        key={notice.id}
+        ref={(el) => {
+          noticeRefs.current[notice.id] = el;
+        }}
+        className={`p-4 border border-gray-200 rounded-lg bg-white shadow-sm transition-all duration-300 ${
+          focusNoticeId === notice.id ? 'ring-2 ring-primary-300 ring-opacity-50' : ''
+        }`}
+      >
+        <div className="flex justify-between items-start mb-2">
+          <PickIcon name={PICK_ICONS.NOTICE} size={20} className="mt-1 mr-2" />
+          <h3 className="font-semibold text-lg text-gray-900 flex-1">{notice.title}</h3>
+          <span className="text-sm text-gray-500 ml-2">
+            {new Date(notice.updatedDate).toLocaleDateString()}
+          </span>
         </div>
+        <p className="text-gray-700 mb-3">{notice.content}</p>
+        {notice.images && notice.images.length > 0 && (
+          <div className="mt-3 flex gap-2 flex-wrap">
+            {notice.images.map((image, index) => (
+              <img
+                key={index}
+                src={image}
+                alt={`공지사항 이미지 ${index + 1}`}
+                onClick={() => handleImageClick(index)}
+                className="w-20 h-20 object-cover rounded border border-gray-200 hover:scale-105 transition-transform duration-200 cursor-pointer"
+              />
+            ))}
+          </div>
+        )}
+
+        {isCurrentUserManager && (
+          <div className="mt-4 pt-3 border-t border-gray-100">
+            <FormSubmitButtons
+              onCancel={() => handleEditNotice(notice.id)}
+              onSubmit={() => handleDeleteNotice(notice.id)}
+              isEdit={false}
+              isDisabled={isDeleting}
+              isLoading={isDeleting}
+              submitLabel="삭제"
+              cancelLabel="수정"
+              submitType="button"
+            />
+          </div>
+        )}
+      </div>
+
+      {isImageModalOpen && (
+        <ImageModal
+          mediaItems={mediaItems}
+          selectedMediaIndex={selectedImageIndex}
+          onClose={() => setIsImageModalOpen(false)}
+          title={notice.title}
+        />
       )}
-    </div>
+    </>
   );
 };

--- a/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeListInfoCard.tsx
+++ b/src/pages/FestivalInfoNoticeList/components/FestivalInfoNoticeListInfoCard.tsx
@@ -19,7 +19,7 @@ const FestivalInfoNoticeListInfoCard = ({
   return (
     <div className="mb-6 p-4 bg-gray-50 rounded-lg cursor-pointer" onClick={onClick}>
       <div className="flex justify-between items-center mb-2">
-        <h3 className="font-semibold text-lg">{title || '공지사항을 작성할 축제'}</h3>
+        <h3 className="font-semibold text-lg break-all">{title || '공지사항을 작성할 축제'}</h3>
         {showCreateButton && onCreateNotice && (
           <Button
             variant="text"
@@ -42,8 +42,8 @@ const FestivalInfoNoticeListInfoCard = ({
           />
         )}
         <div className="flex-1">
-          <p className="font-medium text-gray-900">{festivalData?.title}</p>
-          <p className="text-sm text-gray-600 mt-1">{festivalData?.addr1}</p>
+          <p className="font-medium text-gray-900 break-all">{festivalData?.title}</p>
+          <p className="text-sm text-gray-600 mt-1 break-all">{festivalData?.addr1}</p>
           <p className="text-sm text-gray-500 mt-1">
             {festivalData?.startDate} ~ {festivalData?.endDate}
           </p>

--- a/src/pages/Festivals/components/FestivalCard.tsx
+++ b/src/pages/Festivals/components/FestivalCard.tsx
@@ -41,7 +41,7 @@ const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
 
       {/* 콘텐츠 섹션 */}
       <div className="p-4">
-        <h3 className="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem]">
+        <h3 className="text-lg font-bold text-gray-900 line-clamp-2 leading-tight min-h-[3rem] break-all">
           {data.title}
         </h3>
 
@@ -49,7 +49,7 @@ const FestivalCard = ({ data, highlight = false }: FestivalCardProps) => {
           <p className="text-sm sm:text-xs text-gray-600 font-medium whitespace-nowrap overflow-hidden">
             {data.startDate} ~ {data.endDate}
           </p>
-          <p className="text-sm sm:text-xs text-gray-500" title={data.addr1}>
+          <p className="text-sm sm:text-xs text-gray-500 break-all" title={data.addr1}>
             {data.addr1.split(' ').slice(0, 2).join(' ')}
           </p>
           <div className="flex items-center gap-2 justify-end font-bold">

--- a/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
+++ b/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
@@ -1,3 +1,5 @@
+import TextInputWithCounter from "@/components/form/TextInputWithCounter";
+
 interface ApplicationDepartmentCardProps {
   department: string;
   setDepartment: (department: string) => void;
@@ -17,13 +19,16 @@ const ApplicationDepartmentCard = ({
       <label htmlFor="department" className="block font-semibold mb-2">
         소속 <span className="text-red-500">*</span>
       </label>
-      <input
-        id="department"
-        type="text"
+      <TextInputWithCounter
+        name="department"
+        type="input"
         value={department}
         onChange={(e) => setDepartment(e.target.value)}
         placeholder="예: 부산대학교 축제기획위원회"
         className="w-full p-3 bg-gray-50 rounded-lg border border-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-300"
+        showMinLengthMessage={true}
+        minLengthMessage="최소 2자 이상 입력해주세요"
+        minLength={2}
         maxLength={50}
       />
       <p className="text-xs text-gray-500 mt-1">

--- a/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
+++ b/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
@@ -3,9 +3,11 @@ import TextInputWithCounter from "@/components/form/TextInputWithCounter";
 interface ApplicationDepartmentCardProps {
   department: string;
   setDepartment: (department: string) => void;
+  disabled?: boolean;
 }
 /**
  * 축제 관리자 승급 신청자의 소속을 적는 카드
+ * @param disabled - 비활성화 상태 - 수정 모드일 때는 소속을 변경할 수 없도록 비활성화 상태로 설정합니다.
  * @param department - 축제 관리자 승급 신청자의 소속
  * @param setDepartment - 축제 관리자 승급 신청자의 소속을 설정하는 함수
  * @returns 카드 컴포넌트
@@ -13,6 +15,7 @@ interface ApplicationDepartmentCardProps {
 const ApplicationDepartmentCard = ({
   department,
   setDepartment,
+  disabled = false,
 }: ApplicationDepartmentCardProps) => {
   return (
     <div className="mb-4">
@@ -30,6 +33,7 @@ const ApplicationDepartmentCard = ({
         minLengthMessage="최소 2자 이상 입력해주세요"
         minLength={2}
         maxLength={50}
+        disabled={disabled}
       />
       <p className="text-xs text-gray-500 mt-1">
         소속된 단체, 기관, 부서명을 정확히 입력해주세요. (2-50자)

--- a/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
+++ b/src/pages/SettingsFMPermissionApplication/components/ApplicationDepartmentCard.tsx
@@ -1,4 +1,4 @@
-import TextInputWithCounter from "@/components/form/TextInputWithCounter";
+import TextInputWithCounter from '@/components/form/TextInputWithCounter';
 
 interface ApplicationDepartmentCardProps {
   department: string;

--- a/src/pages/SettingsFMPermissionApplication/components/SettingsFMPermissionApplicationForm.tsx
+++ b/src/pages/SettingsFMPermissionApplication/components/SettingsFMPermissionApplicationForm.tsx
@@ -135,7 +135,11 @@ const SettingsFMPermissionApplicationForm = ({
   };
   return (
     <div className="bg-white rounded-lg p-4 m-4 shadow-sm">
-      <ApplicationDepartmentCard department={department} setDepartment={setDepartment} />
+      <ApplicationDepartmentCard
+        department={department}
+        setDepartment={setDepartment}
+        disabled={isEdit}
+      />
 
       <ApplicationDocumentCard
         documents={documents}

--- a/src/pages/SettingsFMPermissionStatus/components/SettingsFMPermissionButton.tsx
+++ b/src/pages/SettingsFMPermissionStatus/components/SettingsFMPermissionButton.tsx
@@ -26,19 +26,18 @@ const SettingsFMPermissionButton = ({
   const { goBack } = useNav();
   return (
     <div className="flex gap-3 p-4 shadow-sm rounded-lg">
-
       <Button variant="secondary" className="flex-1" onClick={goBack}>
         돌아가기
       </Button>
-      {permission.state === 'ACCEPTED'&& (
-      <Button
-      variant="secondary"
-      className="flex-1 text-red-600 border-red-300 hover:bg-red-50"
-      onClick={handleDelete}
-      disabled={isDeleting}
-       >
-        {isDeleting ? '삭제 중...' : '삭제'}
-      </Button>
+      {permission.state === 'ACCEPTED' && (
+        <Button
+          variant="secondary"
+          className="flex-1 text-red-600 border-red-300 hover:bg-red-50"
+          onClick={handleDelete}
+          disabled={isDeleting}
+        >
+          {isDeleting ? '삭제 중...' : '삭제'}
+        </Button>
       )}
       {permission.state === 'PENDING' && (
         <>

--- a/src/pages/SettingsFMPermissionStatus/components/SettingsFMPermissionButton.tsx
+++ b/src/pages/SettingsFMPermissionStatus/components/SettingsFMPermissionButton.tsx
@@ -26,10 +26,20 @@ const SettingsFMPermissionButton = ({
   const { goBack } = useNav();
   return (
     <div className="flex gap-3 p-4 shadow-sm rounded-lg">
+
       <Button variant="secondary" className="flex-1" onClick={goBack}>
         돌아가기
       </Button>
-
+      {permission.state === 'ACCEPTED'&& (
+      <Button
+      variant="secondary"
+      className="flex-1 text-red-600 border-red-300 hover:bg-red-50"
+      onClick={handleDelete}
+      disabled={isDeleting}
+       >
+        {isDeleting ? '삭제 중...' : '삭제'}
+      </Button>
+      )}
       {permission.state === 'PENDING' && (
         <>
           <Button variant="secondary" className="flex-1" onClick={handleEdit}>

--- a/src/pages/SettingsFestivalMyManageApplication/components/FestivalPermissionCard.tsx
+++ b/src/pages/SettingsFestivalMyManageApplication/components/FestivalPermissionCard.tsx
@@ -28,13 +28,13 @@ const FestivalPermissionCard = ({ permission }: FestivalPermissionCardProps) => 
       <div className="flex items-center justify-between">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-2">
-            <h3 className="font-bold text-lg text-gray-900">{permission.title}</h3>
+            <h3 className="font-bold text-lg text-gray-900 break-all">{permission.title}</h3>
             <span className={`px-3 py-1 rounded-full text-xs font-semibold ${statusInfo.color}`}>
               <PickIcon name={statusInfo.icon} size={16} className="mr-1" />
               {statusInfo.label}
             </span>
           </div>
-          <p className="text-sm text-gray-500">
+          <p className="text-sm text-gray-500 break-all">
             신청일: {new Date(permission.appliedDate).toLocaleDateString()}
           </p>
         </div>

--- a/src/pages/SettingsFestivalMyManageDetail/components/FestivalPermissionInfoCard.tsx
+++ b/src/pages/SettingsFestivalMyManageDetail/components/FestivalPermissionInfoCard.tsx
@@ -25,7 +25,7 @@ const FestivalPermissionInfoCard = ({ permission }: FestivalPermissionInfoCardPr
 
         <div>
           <label className="text-sm text-gray-600">축제명</label>
-          <p className="font-medium text-lg">{permission.title}</p>
+          <p className="font-medium text-lg break-all">{permission.title}</p>
         </div>
 
         <div>

--- a/src/pages/SettingsFestivalMyReview/components/SettingsFestivalMyReviewsCard.tsx
+++ b/src/pages/SettingsFestivalMyReview/components/SettingsFestivalMyReviewsCard.tsx
@@ -26,7 +26,7 @@ const SettingsMyReviewsCard = ({
   return (
     <div key={review.reviewId} className="bg-white rounded-lg p-4 shadow-sm border border-gray-200">
       <div className="flex justify-between items-start mb-2">
-        <h3 className="text-lg font-semibold text-gray-900">{review.festivalTitle}</h3>
+        <h3 className="text-lg font-semibold text-gray-900 break-all">{review.festivalTitle}</h3>
         <StarRating rating={review.score} showScore />
       </div>
 
@@ -58,9 +58,9 @@ const SettingsMyReviewsCard = ({
           />
         </div>
       )}
-      <p className="text-gray-700 mb-3 whitespace-pre-wrap">{review.content}</p>
+      <p className="text-gray-700 mb-3 whitespace-pre-wrap break-all">{review.content}</p>
       <div className="flex justify-between items-center">
-        <div className="text-sm text-gray-500">작성자: {review.reviewerName}</div>
+        <div className="text-sm text-gray-500 break-all">작성자: {review.reviewerName}</div>
         <div className="flex gap-2">
           <button
             onClick={() => handleEditReview(review.reviewId)}


### PR DESCRIPTION
- 전반적으로 백엔드 팀원들과 같이 입력 폼에 있는 글자수들을 맞추고 제한하는 과정을 거쳤습니다.
### TextInputWithCounter 컴포넌트 활용
- HTML maxLength,minLength 속성으로 브라우저 레벨에서 입력 차단 (최소,최대 길이 검증)
- 입력 단계에서 maxLength로 이미 차단되므로 다음 검증은 실행 불가능:
- festivalValidation.ts의 overView 최대 길이 검증 (5000자)
- useChatRoom.ts의 sendMessage 최대 길이 검증 (255자)

거의 기존에 있던 컴포넌트를 재활용하는 방식으로 구현하였고, 축제관리승급 신청서의 경우도 승인되었을때도 삭제할 수 있도록 수정하였습니다.
