### PR TITLE
좋아요, 리뷰하면 캐시 초기화 추가

### DIFF
--- a/src/pages/AiRecommendationHistories/components/AiRecommendationHistoriesContent.tsx
+++ b/src/pages/AiRecommendationHistories/components/AiRecommendationHistoriesContent.tsx
@@ -53,7 +53,7 @@ const AiRecommendationHistoriesContent = () => {
         <div>
           <div className="flex items-center gap-2 mb-4">
             <h3 className="font-bold text-xl text-gray-900">맞춤 추천 축제</h3>
-            <span className="bg-primary-100 text-primary-700 px-2 py-1 rounded-full text-sm font-bold">
+            <span className="bg-primary-100 text-primary-700 px-2.5 py-1 rounded-full text-sm font-bold">
               {festivals.length}
             </span>
           </div>

--- a/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
+++ b/src/pages/FestivalInfo/components/FestivalContentReviewSection.tsx
@@ -31,7 +31,7 @@ const FestivalContentReviewSection = ({
   const { isConfirmOpen, handleDelete, handleConfirmDelete, setIsConfirmOpen } =
     useDeleteWithConfirm(
       deleteReview,
-      [['reviews'], ['festival', festivalId]],
+      [['reviews'], ['festival', festivalId], ['festivals']],
       '리뷰가 삭제되었습니다.',
       '리뷰 삭제에 실패했습니다.',
     );

--- a/src/pages/FestivalInfo/components/FestivalWish.tsx
+++ b/src/pages/FestivalInfo/components/FestivalWish.tsx
@@ -14,6 +14,7 @@ const FestivalWish = ({ isMyWish, wishCount }: { isMyWish: boolean; wishCount: n
     onSuccess: () => {
       setIsWish(true);
       queryClient.invalidateQueries({ queryKey: ['festival', festivalId] });
+      queryClient.invalidateQueries({ queryKey: ['festivals'] });
     },
     onError: () => {
       setIsWish(false);
@@ -24,6 +25,7 @@ const FestivalWish = ({ isMyWish, wishCount }: { isMyWish: boolean; wishCount: n
     onSuccess: () => {
       setIsWish(false);
       queryClient.invalidateQueries({ queryKey: ['festival', festivalId] });
+      queryClient.invalidateQueries({ queryKey: ['festivals'] });
     },
     onError: () => {
       setIsWish(true);

--- a/src/pages/Review/components/ReviewForm.tsx
+++ b/src/pages/Review/components/ReviewForm.tsx
@@ -107,6 +107,7 @@ const ReviewForm = ({
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['reviews', festivalId] });
       queryClient.invalidateQueries({ queryKey: ['festival', festivalId] });
+      queryClient.invalidateQueries({ queryKey: ['festivals'] });
       showToastSuccessMessage(SYSTEM_MESSAGES.REVIEW.SUBMIT_SUCCESS);
       goBack();
     },

--- a/src/pages/ReviewEdit/ReviewEditPage.tsx
+++ b/src/pages/ReviewEdit/ReviewEditPage.tsx
@@ -50,6 +50,7 @@ const ReviewEditPage = () => {
 
       queryClient.invalidateQueries({ queryKey: ['myReviews'] });
       queryClient.invalidateQueries({ queryKey: ['festival'] });
+      queryClient.invalidateQueries({ queryKey: ['festivals'] });
 
       showToastSuccessMessage('리뷰가 수정되었습니다.');
       goBack();


### PR DESCRIPTION
### 축제 목록 페이지
- 좋아요 정보 갱신하면 축제 목록 페이지의 캐시도 초기화하여 새로운 정보를 바로 받아볼 수 있습니다.
- 리뷰 수정, 삭제, 등록하면 축제 목록 페이지 캐시를 삭제합니다

### 축제 AI pick페이지
- 추천 내역 옆 숫자 디자인을 변경했습니다